### PR TITLE
Rename web session default name

### DIFF
--- a/corp104/config/config.go
+++ b/corp104/config/config.go
@@ -432,6 +432,6 @@ func (c *Config) GetWebSessionName() string {
 	if c.WebSessionName != "" {
 		return c.WebSessionName
 	}
-	c.WebSessionName = "sid"
+	c.WebSessionName = "web_sid"
 	return c.WebSessionName
 }


### PR DESCRIPTION
跟既有程式的 session 名稱撞名，所以改名字