### PR TITLE
關閉 user consent flow

### DIFF
--- a/corp104/cmd/root.go
+++ b/corp104/cmd/root.go
@@ -215,6 +215,12 @@ func initConfig() {
 	viper.BindEnv("TRACING_SERVICE_NAME")
 	viper.SetDefault("TRACING_SERVICE_NAME", "Ory Hydra")
 
+	viper.BindEnv("WEB_SESSION_NAME")
+	viper.SetDefault("WEB_SESSION_NAME", "")
+
+	viper.BindEnv("DISABLE_CONSENT_FLOW")
+	viper.SetDefault("DISABLE_CONSENT_FLOW", false)
+
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
 		fmt.Printf(`Config file not found because "%s"`, err)

--- a/corp104/cmd/server/handler_oauth2_factory.go
+++ b/corp104/cmd/server/handler_oauth2_factory.go
@@ -206,7 +206,7 @@ func newOAuth2Handler(c *config.Config, frontend, backend *httprouter.Router, cm
 		OAuth2:           o,
 		ScopeStrategy:    c.GetScopeStrategy(),
 		Consent: consent.NewStrategy(
-			c.LoginURL, c.ConsentURL, c.Issuer,
+			c.LoginURL, c.ConsentURL, c.DisableConsentFlow, c.Issuer,
 			oauth2.AuthPath, cm,
 			sessions.NewCookieStore(c.GetCookieSecret()), c.GetScopeStrategy(),
 			!c.ForceHTTP, time.Minute*15,

--- a/corp104/cmd/token_user.go
+++ b/corp104/cmd/token_user.go
@@ -84,7 +84,7 @@ var tokenUserCmd = &cobra.Command{
 		if frontend == "" {
 			fu, err := url.Parse(c.GetClusterURLWithoutTailingSlashOrFail(cmd))
 			pkg.Must(err, `Unable to parse cluster url ("%s"): %s`, c.GetClusterURLWithoutTailingSlashOrFail(cmd), err)
-			frontend = urlx.AppendPaths(fu, "/oauth2/auth").String()
+			frontend = urlx.AppendPaths(fu, "/authorize").String()
 		}
 
 		conf := oauth2.Config{

--- a/corp104/config/config.go
+++ b/corp104/config/config.go
@@ -96,6 +96,7 @@ type Config struct {
 
 	// Cookie name of web session
 	WebSessionName                   string  `mapstructure:"WEB_SESSION_NAME" yaml:"-"`
+	DisableConsentFlow               bool    `mapstructure:"DISABLE_CONSENT_FLOW" yaml:"-"`
 
 	BuildVersion string                     `yaml:"-"`
 	BuildHash    string                     `yaml:"-"`
@@ -434,4 +435,8 @@ func (c *Config) GetWebSessionName() string {
 	}
 	c.WebSessionName = "web_sid"
 	return c.WebSessionName
+}
+
+func (c *Config) ConsentFlow() bool {
+	return c.DisableConsentFlow
 }

--- a/corp104/consent/strategy_default.go
+++ b/corp104/consent/strategy_default.go
@@ -54,6 +54,7 @@ const (
 type DefaultStrategy struct {
 	AuthenticationURL             string
 	ConsentURL                    string
+	DisableUserConsent            bool
 	IssuerURL                     string
 	OAuth2AuthURL                 string
 	M                             Manager
@@ -69,6 +70,7 @@ type DefaultStrategy struct {
 func NewStrategy(
 	authenticationURL string,
 	consentURL string,
+	disableUserConsent bool,
 	issuerURL string,
 	oAuth2AuthURL string,
 	m Manager,
@@ -83,6 +85,7 @@ func NewStrategy(
 	return &DefaultStrategy{
 		AuthenticationURL:             authenticationURL,
 		ConsentURL:                    consentURL,
+		DisableUserConsent:            disableUserConsent,
 		IssuerURL:                     issuerURL,
 		OAuth2AuthURL:                 oAuth2AuthURL,
 		M:                             m,
@@ -562,10 +565,11 @@ func (s *DefaultStrategy) verifyConsent(w http.ResponseWriter, r *http.Request, 
 		return nil, errors.WithStack(fosite.ErrServerError.WithDebug("The authenticatedAt value was not set."))
 	}
 
-	// 沒有重導至 User Agent，因此無須查驗 CSRF
-	//if err := validateCsrfSession(r, s.CookieStore, cookieConsentCSRFName, session.ConsentRequest.CSRF); err != nil {
-	//	return nil, err
-	//}
+	if !s.DisableUserConsent {
+		if err := validateCsrfSession(r, s.CookieStore, cookieConsentCSRFName, session.ConsentRequest.CSRF); err != nil {
+			return nil, err
+		}
+	}
 
 	pw, err := s.obfuscateSubjectIdentifier(session.ConsentRequest.Subject, req, session.ConsentRequest.ForceSubjectIdentifier)
 	if err != nil {
@@ -601,20 +605,25 @@ func (s *DefaultStrategy) HandleOAuth2AuthorizationRequest(w http.ResponseWriter
 			return nil, err
 		}
 
-		// 建立 consent request
-		challenge, verifier, err := s.createConsentRequest(w, r, req, authSession)
-		if err != nil {
-			return nil, err
-		}
+		if s.DisableUserConsent {
+			// 建立 consent request
+			challenge, verifier, err := s.createConsentRequest(w, r, req, authSession)
+			if err != nil {
+				return nil, err
+			}
 
-		// 不 redirect 出去，直接處理掉
-		err = s.handleConsentRequest(w, r, req, challenge)
-		if err != nil {
-			return nil, err
-		}
+			// 不 redirect 出去，直接處理掉
+			err = s.handleConsentRequest(w, r, req, challenge)
+			if err != nil {
+				return nil, err
+			}
 
-		// 重設原本預計從 query string 拿取的 consent_verifier
-		consentVerifier = verifier
+			// 重設原本預計從 query string 拿取的 consent_verifier
+			consentVerifier = verifier
+		} else {
+			// ok, we need to process this request and redirect to auth endpoint
+			return nil, s.requestConsent(w, r, req, authSession)
+		}
 	}
 
 	consentSession, err := s.verifyConsent(w, r, req, consentVerifier)
@@ -626,6 +635,26 @@ func (s *DefaultStrategy) HandleOAuth2AuthorizationRequest(w http.ResponseWriter
 }
 
 func (s *DefaultStrategy) createConsentRequest(w http.ResponseWriter, r *http.Request, req fosite.AuthorizeRequester, authSession *HandledAuthenticationRequest) (challenge string, verifier string, err error) {
+
+	prompt := stringsx.Splitx(req.GetRequestForm().Get("prompt"), " ")
+	if stringslice.Has(prompt, "consent") {
+		return "", "", errors.WithStack(fosite.ErrConsentRequired.WithDebug(`Prompt "consent" was not supported`))
+	}
+
+	consentSessions, err := s.M.FindPreviouslyGrantedConsentRequests(r.Context(), req.GetClient().GetID(), authSession.Subject)
+	if err != nil && errors.Cause(err) != ErrNoPreviousConsentFound{
+		return "", "", err
+	}
+
+	skip := false
+	found := matchScopes(s.ScopeStrategy, consentSessions, req.GetRequestedScopes())
+	if found != nil {
+		skip = true
+	}
+
+	if stringslice.Has(prompt, "none") && !skip {
+		return "", "", errors.WithStack(fosite.ErrConsentRequired.WithDebug(`Prompt "none" was requested, but no previous consent was found`))
+	}
 
 	// Set up csrf/challenge/verifier values
 	v := strings.Replace(uuid.New(), "-", "", -1)
@@ -667,6 +696,7 @@ func (s *DefaultStrategy) handleConsentRequest(w http.ResponseWriter, r *http.Re
 
 	p.Challenge = challenge
 	p.RequestedAt = cr.RequestedAt
+	p.GrantedScope = []string(req.GetRequestedScopes())
 
 	hr, err := s.M.HandleConsentRequest(r.Context(), challenge, &p)
 	if err != nil {

--- a/corp104/consent/strategy_default_test.go
+++ b/corp104/consent/strategy_default_test.go
@@ -131,6 +131,7 @@ func TestStrategy(t *testing.T) {
 	strategy := NewStrategy(
 		lp.URL,
 		cp.URL,
+		false,
 		ap.URL,
 		"/oauth2/auth",
 		manager,

--- a/corp104/oauth2/oauth2_auth_code_test.go
+++ b/corp104/oauth2/oauth2_auth_code_test.go
@@ -160,7 +160,7 @@ func TestAuthCodeWithDefaultStrategy(t *testing.T) {
 					cookieStore := sessions.NewCookieStore([]byte("foo-secret"))
 
 					consentStrategy := consent.NewStrategy(
-						lp.URL, cp.URL, ts.URL, AuthPath, cm,
+						lp.URL, cp.URL, false, ts.URL, AuthPath, cm,
 						cookieStore,
 						fosite.ExactScopeStrategy, false, time.Hour, jwts,
 						openid.NewOpenIDConnectRequestValidator(nil, jwts),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       - OIDC_SUBJECT_TYPES_SUPPORTED=public
       - OIDC_SUBJECT_TYPE_PAIRWISE_SALT=youReallyNeedToChangeThis
       - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
+      - DISABLE_CONSENT_FLOW=1
     restart: on-failure
 
   consent:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     links:
       - postgresd:postgresd
     environment:
-#      - LOG_LEVEL=debug
+      - LOG_LEVEL=debug
       - DATABASE_URL=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable
     command:
       migrate sql -e
@@ -47,7 +47,7 @@ services:
     command:
       serve all --dangerous-force-http
     environment:
-#      - LOG_LEVEL=debug
+      - LOG_LEVEL=debug
       - OAUTH2_ISSUER_URL=http://localhost:4444
       - OAUTH2_CONSENT_URL=http://localhost:3000/consent
       - OAUTH2_LOGIN_URL=http://localhost:3000/login
@@ -56,9 +56,9 @@ services:
 #      - DATABASE_URL=mysql://root:secret@tcp(mysqld:3306)/mysql?parseTime=true
       - SYSTEM_SECRET=youReallyNeedToChangeThis
       - OAUTH2_SHARE_ERROR_DEBUG=1
-      - OIDC_SUBJECT_TYPES_SUPPORTED=public,pairwise
+      - OIDC_SUBJECT_TYPES_SUPPORTED=public
       - OIDC_SUBJECT_TYPE_PAIRWISE_SALT=youReallyNeedToChangeThis
-#     - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
+      - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
     restart: on-failure
 
   consent:


### PR DESCRIPTION
## 關閉 Consent flow

既有 hydra 內存在 [User Login and Consent Flow](https://www.ory.sh/docs/guides/master/hydra/3-overview/)，我們不需要使用者授權頁，因此關閉

副作用是，由於 scope 原本會在授權頁讓 end user 勾選，現在暫時無條件接受
