### PR TITLE
為每個 route 新增 Web Session 檢查的 middleware

### DIFF
--- a/corp104/cmd/root.go
+++ b/corp104/cmd/root.go
@@ -77,7 +77,7 @@ func init() {
 	// will be global for your application.
 
 	//RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file (default is $HOME/.hydra.yaml)")
-	RootCmd.PersistentFlags().Bool("skip-tls-verify", false, "Foolishly accept TLS certificates signed by unkown certificate authorities")
+	RootCmd.PersistentFlags().Bool("skip-tls-verify", false, "Foolishly accept TLS certificates signed by unknown certificate authorities")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
@@ -217,6 +217,9 @@ func initConfig() {
 
 	viper.BindEnv("WEB_SESSION_NAME")
 	viper.SetDefault("WEB_SESSION_NAME", "")
+
+	viper.BindEnv("BY_PASS_ROUTES")
+	viper.SetDefault("BY_PASS_ROUTES", "")
 
 	viper.BindEnv("DISABLE_CONSENT_FLOW")
 	viper.SetDefault("DISABLE_CONSENT_FLOW", false)

--- a/corp104/config/config.go
+++ b/corp104/config/config.go
@@ -96,6 +96,7 @@ type Config struct {
 
 	// Cookie name of web session
 	WebSessionName                   string  `mapstructure:"WEB_SESSION_NAME" yaml:"-"`
+	ByPassSessionCheckRoutes		 string  `mapstructure:"BY_PASS_ROUTES" yaml:"-"`
 	DisableConsentFlow               bool    `mapstructure:"DISABLE_CONSENT_FLOW" yaml:"-"`
 
 	BuildVersion string                     `yaml:"-"`
@@ -435,6 +436,14 @@ func (c *Config) GetWebSessionName() string {
 	}
 	c.WebSessionName = "web_sid"
 	return c.WebSessionName
+}
+
+func (c *Config) GetByPassSessionCheckRoutes() []string {
+	if c.ByPassSessionCheckRoutes == "" {
+		return nil
+	}
+
+	return strings.Split(c.ByPassSessionCheckRoutes, ",")
 }
 
 func (c *Config) ConsentFlow() bool {

--- a/corp104/config/web_session.go
+++ b/corp104/config/web_session.go
@@ -14,7 +14,7 @@ func NewWebSession(c *Config) (session *WebSession) {
 	store.Options(sessions.Options{
 		Path:     "/",
 		MaxAge:   0,
-		Secure:   false,
+		Secure:   !c.ForceHTTP,
 		HTTPOnly: true,
 	})
 	return &WebSession{

--- a/docker-compose-twoc.yml
+++ b/docker-compose-twoc.yml
@@ -53,6 +53,7 @@ services:
       - OAUTH2_SHARE_ERROR_DEBUG=1
       - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
       - DISABLE_CONSENT_FLOW=1
+      - BY_PASS_ROUTES=/register,/authorize
     restart: on-failure
 
   hydra:
@@ -81,6 +82,7 @@ services:
       - OAUTH2_SHARE_ERROR_DEBUG=1
       - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
       - DISABLE_CONSENT_FLOW=1
+      - BY_PASS_ROUTES=/register,/authorize
     restart: on-failure
 
   consent:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       - OIDC_SUBJECT_TYPE_PAIRWISE_SALT=youReallyNeedToChangeThis
       - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
       - DISABLE_CONSENT_FLOW=1
+      - BY_PASS_ROUTES=/register,/authorize
     restart: on-failure
 
   consent:


### PR DESCRIPTION
1. 新增 `BY_PASS_ROUTES` 環境變數，可指定特定路徑跳過檢查
2. 每個路徑會先檢查 session 內是有否 `client_metadata`，但為了測試，暫時先 stub 成通過
3. bypass 的路徑，目前只會比對 path 的第一層

```
假設 /register 可跳過 web session 檢查

以下路徑皆符合
/register
/register/xxx
/register/xxx/yyy 依此類推
```