### PR TITLE
Add wiremock to mock external resource dependency

### DIFF
--- a/corp104/client/handler.go
+++ b/corp104/client/handler.go
@@ -21,13 +21,12 @@
 package client
 
 import (
-	"context"
 	"encoding/json"
 	"github.com/goincremental/negroni-sessions"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwe"
-	"github.com/lestrrat-go/jwx/jws"
 	"github.com/ory/hydra/corp104/jwk"
+	"github.com/ory/hydra/pkg"
 	"github.com/ory/hydra/rand/sequence"
 	"gopkg.in/square/go-jose.v2"
 	"net/http"
@@ -97,28 +96,40 @@ func (h *Handler) SetRoutes(r *httprouter.Router) {
 //       500: genericError
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	// Get software_statement from payload
-	swStatement, err := getSoftwareStatement(r)
+	swStatement, err := pkg.GetJWTValueFromRequestBody(r, "software_statement")
 	if err != nil {
 		h.H.WriteError(w, r, errors.WithStack(err))
 		return
 	}
 
-	// Extract kid from JWE header and get private key of oauth server
-	authSrvPrivKey, err := getOAuthServerPrivateKey(r.Context(), h.KeyManager, swStatement)
+	// Extract kid from JWE header
+	kid, err := pkg.ExtractKidFromJWE(swStatement)
+	if err != nil {
+		h.H.WriteError(w, r, errors.WithStack(err))
+		return
+	}
+	// Extract key set
+	keySet, err := h.KeyManager.GetKeysById(r.Context(), kid)
+	if err != nil {
+		h.H.WriteError(w, r, errors.WithStack(err))
+		return
+	}
+	// Get private key of oauth server
+	authSrvPrivateKey, err := pkg.GetElementFromKeySet(keySet, kid)
 	if err != nil {
 		h.H.WriteError(w, r, errors.WithStack(err))
 		return
 	}
 
 	// JWE decryption using private key of oauth server
-	decryptedMsg, err := jwe.Decrypt(swStatement, jwa.ECDH_ES_A256KW, authSrvPrivKey.Key)
+	decryptedMsg, err := jwe.Decrypt(swStatement, jwa.ECDH_ES_A256KW, authSrvPrivateKey.Key)
 	if err != nil {
 		h.H.WriteError(w, r, errors.WithStack(err))
 		return
 	}
 
 	// JWS Verification using client's public key
-	verifiedMsg, err := verifySoftwareStatementJWS(decryptedMsg)
+	verifiedMsg, err := pkg.VerifyJWS(decryptedMsg, checkClientMetadata)
 	if err != nil {
 		h.H.WriteError(w, r, errors.WithStack(err))
 		return
@@ -155,7 +166,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	saveClientMetadataToSession(r, string(verifiedMsg))
 
 	// Create registration response
-	registrationResponse, err := createRegistrationResponse(authSrvPrivKey, c.GetID())
+	registrationResponse, err := createRegistrationResponse(authSrvPrivateKey, c.GetID())
 	if err := h.Validator.Validate(&c); err != nil {
 		h.H.WriteError(w, r, err)
 		return
@@ -320,87 +331,25 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func getSoftwareStatement(r *http.Request) ([]byte, error) {
-	var body map[string]string
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		return nil, err
-	}
-	swStatement := body["software_statement"]
-	if swStatement == "" {
-		return nil, errors.New("Empty \"software_statement\"")
-	}
-	return []byte(swStatement), nil
-}
-
-func getOAuthServerPrivateKey(ctx context.Context, keyManager jwk.Manager, swStatementJwe []byte) (*jose.JSONWebKey, error) {
-	jweMessage, err := jwe.Parse(swStatementJwe)
-	if err != nil {
-		return nil, err
-	}
-	if len(jweMessage.Recipients) < 1 {
-		return nil, errors.New("\"kid\" not found in JWE header")
-	}
-	serverKeyId := jweMessage.Recipients[0].Header.KeyID
-	if serverKeyId == "" {
-		return nil, errors.New("\"kid\" not found in JWE header")
-	}
-	serverKeyId = strings.Replace(serverKeyId, "public:", "private:",1)
-	setKeys, err := keyManager.GetKeysById(ctx, serverKeyId)
-	if err != nil {
-		return nil, err
-	}
-	for _, keys := range setKeys {
-		for _, key := range keys {
-			if key.KeyID == serverKeyId && !key.IsPublic() {
-				return &key, nil
-			}
-		}
-	}
-	return nil, errors.New("JSONWebKey not found for kid: " + serverKeyId)
-}
-
-func verifySoftwareStatementJWS(compactJws []byte) ([]byte, error) {
-	// get jwk from JOSE header
-	headers, err := getHeadersFromJws(string(compactJws))
-	if err != nil {
-		return nil, err
-	}
+func checkClientMetadata(json map[string]interface{}) error {
 
 	// validate `typ` should be `client-metadata+jwt` or `application/client-metadata+jwt`
-	typ, found := headers["typ"]
+	typ, found := json["typ"]
 	if !found {
-		return nil, errors.New("`typ` not found in JOSE header")
+		return errors.New("`typ` not found in JOSE header")
 	}
 	if typ, ok := typ.(string); ok {
 		if !strings.HasPrefix(typ, "application/") {
 			typ = "application/" + typ
 		}
 		if typ != "application/client-metadata+jwt" {
-			return nil, errors.New("`typ` should be \"application/client-metadata+jwt\"")
+			return errors.New("`typ` should be \"application/client-metadata+jwt\"")
 		}
 	} else {
-		return nil, errors.New("Invalid `typ` declaration")
+		return errors.New("Invalid `typ` declaration")
 	}
 
-	pubJwkHeader, found := headers["jwk"]
-	if !found {
-		return nil, errors.New("`jwk` not found in JOSE header")
-	}
-	pubJwsJson, err := json.Marshal(&pubJwkHeader)
-	if err != nil {
-		return nil, err
-	}
-	pubJwk := &jose.JSONWebKey{}
-	err = pubJwk.UnmarshalJSON(pubJwsJson)
-	if err != nil {
-		return nil, err
-	}
-
-	verifiedMsg, err := jws.Verify(compactJws, jwa.ES256, pubJwk.Key)
-	if err != nil {
-		return nil, err
-	}
-	return verifiedMsg, nil
+	return nil
 }
 
 func saveClientMetadataToSession(r *http.Request, metadata string) {
@@ -408,26 +357,14 @@ func saveClientMetadataToSession(r *http.Request, metadata string) {
 	session.Set("client_metadata", metadata)
 }
 
-func createRegistrationResponse(authSrvPrivKey *jose.JSONWebKey, clientId string) (*RegistrationResponse, error) {
-	headers := &jws.StandardHeaders{}
-	headers.Set("alg", authSrvPrivKey.Algorithm)
-	headers.Set("typ", "JWT")
-	headers.Set("kid", strings.Replace(authSrvPrivKey.KeyID, "private:", "public:", 1))
-
+func createRegistrationResponse(authSrvPrivateKey *jose.JSONWebKey, clientId string) (*RegistrationResponse, error) {
 	claims := make(map[string]string)
 	claims["client_id"] = clientId
 
-	payload, err := json.Marshal(claims)
+	responseJwt, err := pkg.GenerateResponseJWT(authSrvPrivateKey, claims)
 	if err != nil {
 		return nil, err
 	}
 
-	buf, err := jws.Sign(payload, jwa.ES256, authSrvPrivKey.Key, jws.WithHeaders(headers))
-	if err != nil {
-		return nil, err
-	}
-
-	return &RegistrationResponse{
-		SignedClientId: string(buf),
-	}, nil
+	return &RegistrationResponse{SignedClientId: responseJwt}, nil
 }

--- a/corp104/client/helper.go
+++ b/corp104/client/helper.go
@@ -1,11 +1,7 @@
 package client
 
 import (
-	"encoding/base64"
-	"encoding/json"
-	"github.com/lestrrat-go/jwx/jws"
 	"github.com/ory/go-convenience/stringslice"
-	"strings"
 )
 
 func hasStrings(s1 []string, s2... string) bool {
@@ -18,21 +14,4 @@ func hasStrings(s1 []string, s2... string) bool {
 		}
 	}
 	return true
-}
-
-func getHeadersFromJws(compactJws string) (map[string]interface{}, error) {
-	compactHeader, _, _, err := jws.SplitCompact(strings.NewReader(compactJws))
-	if err != nil {
-		return nil, err
-	}
-	headerJson, err := base64.RawURLEncoding.DecodeString(string(compactHeader))
-	if err != nil {
-		return nil, err
-	}
-	headers := make(map[string]interface{})
-	err = json.Unmarshal(headerJson, &headers)
-	if err != nil {
-		return nil, err
-	}
-	return headers, nil
 }

--- a/dep/login/mappings/login.json
+++ b/dep/login/mappings/login.json
@@ -1,0 +1,30 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/login",
+    "headers": {
+      "Content-Type": {
+        "equalTo": "application/json"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "equalToJson": "{ 'loginid': 'foo@bar.com', 'password': 'foobar' }"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8",
+      "Cache-Control": "no-cache"
+    },
+    "jsonBody": {
+      "error": "",
+      "success": "true",
+      "data": {
+        "id": "123456"
+      }
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,8 @@ services:
       - OIDC_SUBJECT_TYPE_PAIRWISE_SALT=youReallyNeedToChangeThis
       - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
       - DISABLE_CONSENT_FLOW=1
-      - BY_PASS_ROUTES=/register,/authorize
+      - BY_PASS_ROUTES=/register
+      - CORS_ENABLED=1
     restart: on-failure
 
   consent:
@@ -87,3 +88,13 @@ services:
 #    image: mysql:5.7
 #    environment:
 #      - MYSQL_ROOT_PASSWORD=secret
+
+  login-dep:
+    image: ekino/wiremock:latest
+    links:
+      - hydra
+    ports:
+      - 9999:8080
+    volumes:
+      - "./dep/login/__files:/wiremock/__files"
+      - "./dep/login/mappings:/wiremock/mappings"


### PR DESCRIPTION
## Mock
1. 使用 Wiremock 處理 API mock server，主要是提供 docker 環境的 API stub
2. 移除 mock 的回傳欄位內，跟公司業務相關的資訊

## 將共用函示抽到 jose-util.go
下述操作流程，在很多地方都會用到，因而抽到 pkg/jose-util.go

Step 1：從 HTTP request body 中，將某個欄位取出，裡面是 JWT、JWE 字串

```Go
statement, err := pkg.GetJWTValueFromRequestBody(r, "software_statement")
```

Step 2：取出 JWT、JWE 表頭的 kid

```Go
kid, err := pkg.ExtractKidFromJWE(statement)
```

Step 3：從 key set 中取出該 kid 的 key

```Go
authSrvPrivateKey, err := pkg.GetElementFromKeySet(keySet, kid)
```

Step 4：解開 JWE（這步驟無任何修改）

```Go
jwe.Decrypt(statement, jwa.ECDH_ES_A256KW, authSrvPrivateKey.Key)
```

Step 5：查驗解密後的 JWS

```Go
verifiedMsg, err := pkg.VerifyJWS(decryptedMsg, checkClientMetadata) // 後面是一個 func，可以做任何表頭欄位的查驗
```

Step 6：做了某些事情後，會需要產生一個 JWT，裡面可以是任意的 claims

```Go
func createRegistrationResponse(authSrvPrivateKey *jose.JSONWebKey, clientId string) (*RegistrationResponse, error) {
    ... 略
    response, err := pkg.GenerateResponseJWT(authSrvPrivateKey, claims)
    ... 略
}
```