### PR TITLE
增加 login route 處理使用者帳號密碼

### DIFF
--- a/corp104/client/handler.go
+++ b/corp104/client/handler.go
@@ -129,7 +129,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	}
 
 	// JWS Verification using client's public key
-	verifiedMsg, err := pkg.VerifyJWS(decryptedMsg, checkClientMetadata)
+	verifiedMsg, err := pkg.VerifyJWS(decryptedMsg, checkClientMetadata, nil)
 	if err != nil {
 		h.H.WriteError(w, r, errors.WithStack(err))
 		return

--- a/corp104/cmd/root.go
+++ b/corp104/cmd/root.go
@@ -224,6 +224,9 @@ func initConfig() {
 	viper.BindEnv("DISABLE_CONSENT_FLOW")
 	viper.SetDefault("DISABLE_CONSENT_FLOW", false)
 
+	viper.BindEnv("CORP_INTERNAL_API_URL")
+	viper.SetDefault("CORP_INTERNAL_API_URL", "")
+
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
 		fmt.Printf(`Config file not found because "%s"`, err)

--- a/corp104/cmd/server/handler_consent_factory.go
+++ b/corp104/cmd/server/handler_consent_factory.go
@@ -41,7 +41,7 @@ func newConsentHandler(c *config.Config, frontend, backend *httprouter.Router) *
 	w.ErrorEnhancer = writerErrorEnhancer
 
 	expectDependency(c.GetLogger(), ctx.ConsentManager)
-	h := consent.NewHandler(w, ctx.ConsentManager, sessions.NewCookieStore(c.GetCookieSecret()), c.LogoutRedirectURL)
+	h := consent.NewHandler(w, ctx.ConsentManager, sessions.NewCookieStore(c.GetCookieSecret()), c.LogoutRedirectURL, c.Context().KeyManager)
 	h.SetRoutes(frontend, backend)
 	return h
 }

--- a/corp104/config/config.go
+++ b/corp104/config/config.go
@@ -98,6 +98,7 @@ type Config struct {
 	WebSessionName                   string  `mapstructure:"WEB_SESSION_NAME" yaml:"-"`
 	ByPassSessionCheckRoutes		 string  `mapstructure:"BY_PASS_ROUTES" yaml:"-"`
 	DisableConsentFlow               bool    `mapstructure:"DISABLE_CONSENT_FLOW" yaml:"-"`
+	CorpInternalAPIUrl               string  `mapstructure:"CORP_INTERNAL_API_URL" yaml:"-"`
 
 	BuildVersion string                     `yaml:"-"`
 	BuildHash    string                     `yaml:"-"`

--- a/corp104/consent/handler.go
+++ b/corp104/consent/handler.go
@@ -22,6 +22,11 @@ package consent
 
 import (
 	"encoding/json"
+	"github.com/go-resty/resty"
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/jwe"
+	"github.com/ory/hydra/pkg"
+	"github.com/spf13/viper"
 	"net/http"
 	"net/url"
 	"time"
@@ -49,6 +54,7 @@ const (
 	LoginPath    = "/oauth2/auth/requests/login"
 	ConsentPath  = "/oauth2/auth/requests/consent"
 	SessionsPath = "/oauth2/auth/sessions"
+	IdpPath      = "/login"
 )
 
 func NewHandler(
@@ -82,6 +88,8 @@ func (h *Handler) SetRoutes(frontend, backend *httprouter.Router) {
 	backend.DELETE(SessionsPath+"/consent/:user/:client", h.DeleteUserClientConsentSession)
 
 	frontend.GET(SessionsPath+"/login/revoke", h.LogoutUser)
+
+	frontend.POST(IdpPath, h.AuthUser)
 }
 
 // swagger:route DELETE /oauth2/auth/sessions/consent/{user} oAuth2 revokeAllUserConsentSessions
@@ -618,4 +626,110 @@ func (h *Handler) LogoutUser(w http.ResponseWriter, r *http.Request, ps httprout
 	}
 
 	http.Redirect(w, r, h.LogoutRedirectURL, 302)
+}
+
+func (h *Handler) AuthUser(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+
+	msg, err := h.verifyJWS(w, r, "signed_credentials", nil, checkPayload)
+	if err != nil {
+		h.H.WriteError(w, r, err)
+		return
+	}
+
+	claims := make(map[string]string)
+	if err := json.Unmarshal(msg, &claims); err != nil {
+		h.H.WriteError(w, r, errors.WithStack(err))
+		return
+	}
+
+	request, err := h.M.GetAuthenticationRequest(r.Context(), claims["challenge"])
+	if err != nil {
+		h.H.WriteError(w, r, err)
+		return
+	}
+
+	if request.Client.ClientID != claims["client_id"] {
+		h.H.WriteError(w, r, errors.WithStack(fosite.ErrInvalidRequest.WithDebug("Client id is wrong")))
+		return
+	}
+
+	apiBaseUrl := viper.GetString("CORP_INTERNAL_API_URL")
+	if apiBaseUrl == "" {
+		h.H.WriteError(w, r, errors.WithStack(fosite.ErrInvalidRequest.WithDebug("No corp internal api url")))
+		return
+	}
+	body := `{"username":"` + claims["username"] + `","password":"` + claims["password"] + `"}`
+
+	resp, err := resty.R().SetHeader("Content-Type", "application/json").SetBody(body).Post(apiBaseUrl + "/login")
+	if err != nil {
+		h.H.WriteError(w, r, errors.WithStack(err))
+		return
+	}
+
+	responseMap := make(map[string]string)
+	if err := json.Unmarshal(resp.Body(), &responseMap); err != nil {
+		h.H.WriteError(w, r, errors.WithStack(err))
+		return
+	}
+
+	if responseMap["error"] == "" {
+		h.H.Write(w, r, `{"ok": true, "id":"` + responseMap["id"] + `"}`)
+	} else {
+		h.H.Write(w, r, `{"ok": false, "id":"` + responseMap["id"] + `"}`)
+	}
+}
+
+func (h *Handler) verifyJWS(w http.ResponseWriter, r *http.Request, field string, headerChecker func(map[string]interface{}) (error), payloadChecker func(map[string]interface{}) (error)) ([]byte, error) {
+
+	credential, err := pkg.GetJWTValueFromRequestBody(r, field)
+	if err != nil {
+		h.H.WriteError(w, r, errors.WithStack(err))
+		return nil, err
+	}
+
+	// Extract kid from JWE header
+	kid, err := pkg.ExtractKidFromJWE(credential)
+	if err != nil {
+		h.H.WriteError(w, r, errors.WithStack(err))
+		return nil, err
+	}
+	// Extract key set
+	keySet, err := h.KeyManager.GetKeysById(r.Context(), kid)
+	if err != nil {
+		h.H.WriteError(w, r, errors.WithStack(err))
+		return nil, err
+	}
+	// Get private key of oauth server
+	authSrvPrivateKey, err := pkg.GetElementFromKeySet(keySet, kid)
+	if err != nil {
+		h.H.WriteError(w, r, errors.WithStack(err))
+		return nil, err
+	}
+
+	// JWE decryption using private key of oauth server
+	decryptedMsg, err := jwe.Decrypt(credential, jwa.ECDH_ES_A256KW, authSrvPrivateKey.Key)
+	if err != nil {
+		h.H.WriteError(w, r, errors.WithStack(err))
+		return nil, err
+	}
+
+	// JWS Verification using client's public key
+	verifiedMsg, err := pkg.VerifyJWS(decryptedMsg, headerChecker, payloadChecker)
+	if err != nil {
+		h.H.WriteError(w, r, errors.WithStack(err))
+		return nil, err
+	}
+
+	return verifiedMsg, nil
+}
+
+func checkPayload(json map[string]interface{}) error {
+	required := []string{"challenge", "client_id", "username", "password"}
+	for _, v := range required {
+		if _, ok := json[v]; !ok {
+			return errors.WithStack(fosite.ErrInvalidRequest.WithDebug(v + " is missing"))
+		}
+	}
+
+	return nil
 }

--- a/corp104/consent/handler.go
+++ b/corp104/consent/handler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ory/fosite"
 	"github.com/ory/go-convenience/urlx"
 	"github.com/ory/herodot"
+	"github.com/ory/hydra/corp104/jwk"
 	"github.com/ory/pagination"
 	"github.com/pkg/errors"
 )
@@ -41,6 +42,7 @@ type Handler struct {
 	LogoutRedirectURL string
 	RequestMaxAge     time.Duration
 	CookieStore       sessions.Store
+	KeyManager        jwk.Manager
 }
 
 const (
@@ -54,12 +56,14 @@ func NewHandler(
 	m Manager,
 	c sessions.Store,
 	u string,
+	k jwk.Manager,
 ) *Handler {
 	return &Handler{
 		H:                 h,
 		M:                 m,
 		LogoutRedirectURL: u,
 		CookieStore:       c,
+		KeyManager:        k,
 	}
 }
 

--- a/corp104/consent/handler_test.go
+++ b/corp104/consent/handler_test.go
@@ -21,6 +21,8 @@
 package consent
 
 import (
+	"github.com/ory/hydra/corp104/jwk"
+	"gopkg.in/square/go-jose.v2"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -39,6 +41,7 @@ import (
 )
 
 func TestLogout(t *testing.T) {
+	keyManager := &jwk.MemoryManager{Keys: map[string]*jose.JSONWebKeySet{}}
 	cs := sessions.NewCookieStore([]byte("secret"))
 	r := httprouter.New()
 	h := NewHandler(
@@ -46,6 +49,7 @@ func TestLogout(t *testing.T) {
 		NewMemoryManager(nil),
 		cs,
 		"https://www.ory.sh",
+		keyManager,
 	)
 
 	sid := uuid.New()

--- a/corp104/consent/strategy_default_test.go
+++ b/corp104/consent/strategy_default_test.go
@@ -25,6 +25,8 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
+	"github.com/ory/hydra/corp104/jwk"
+	"gopkg.in/square/go-jose.v2"
 	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
@@ -123,7 +125,8 @@ func TestStrategy(t *testing.T) {
 	cs := sessions.NewCookieStore([]byte("dummy-secret-yay"))
 	writer := herodot.NewJSONWriter(nil)
 	manager := NewMemoryManager(nil)
-	handler := NewHandler(writer, manager, cs, "https://www.ory.sh")
+	keyManager := &jwk.MemoryManager{Keys: map[string]*jose.JSONWebKeySet{}}
+	handler := NewHandler(writer, manager, cs, "https://www.ory.sh", keyManager)
 	router := httprouter.New()
 	handler.SetRoutes(router, router)
 	api := httptest.NewServer(router)

--- a/corp104/oauth2/oauth2_auth_code_test.go
+++ b/corp104/oauth2/oauth2_auth_code_test.go
@@ -201,7 +201,7 @@ func _TestAuthCodeWithDefaultStrategy(t *testing.T) {
 						return h
 					})
 
-					apiHandler := consent.NewHandler(herodot.NewJSONWriter(l), cm, cookieStore, "")
+					apiHandler := consent.NewHandler(herodot.NewJSONWriter(l), cm, cookieStore, "", jm)
 					apiRouter := httprouter.New()
 					apiHandler.SetRoutes(apiRouter, apiRouter)
 					api := httptest.NewServer(apiRouter)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       dockerfile: Dockerfile
     links:
       - postgresd:postgresd
+      - login-dep
 #     Uncomment the following line to use mysql instead.
 #      - mysqld:mysqld
     depends_on:
@@ -62,6 +63,7 @@ services:
       - DISABLE_CONSENT_FLOW=1
       - BY_PASS_ROUTES=/register
       - CORS_ENABLED=1
+      - CORP_INTERNAL_API_URL=http://login-dep:8080
     restart: on-failure
 
   consent:
@@ -91,10 +93,8 @@ services:
 
   login-dep:
     image: ekino/wiremock:latest
-    links:
-      - hydra
     ports:
-      - 9999:8080
+      - 8080:8080
     volumes:
-      - "./dep/login/__files:/wiremock/__files"
-      - "./dep/login/mappings:/wiremock/mappings"
+      - "./mock-dep/login/__files:/wiremock/__files"
+      - "./mock-dep/login/mappings:/wiremock/mappings"

--- a/mock-dep/login/mappings/login_failed.json
+++ b/mock-dep/login/mappings/login_failed.json
@@ -9,7 +9,7 @@
     },
     "bodyPatterns": [
       {
-        "equalToJson": "{ 'loginid': 'foo@bar.com', 'password': 'foobar' }"
+        "equalToJson": "{ 'username': 'foo@bar.com', 'password': 'foo' }"
       }
     ]
   },
@@ -20,11 +20,8 @@
       "Cache-Control": "no-cache"
     },
     "jsonBody": {
-      "error": "",
-      "success": "true",
-      "data": {
-        "id": "123456"
-      }
+      "error": "Unable to login",
+      "id": ""
     }
   }
 }

--- a/mock-dep/login/mappings/login_successful.json
+++ b/mock-dep/login/mappings/login_successful.json
@@ -1,0 +1,27 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/login",
+    "headers": {
+      "Content-Type": {
+        "equalTo": "application/json"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "equalToJson": "{ 'username': 'foo@bar.com', 'password': 'foobar' }"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8",
+      "Cache-Control": "no-cache"
+    },
+    "jsonBody": {
+      "error": "",
+      "id": "123456"
+    }
+  }
+}


### PR DESCRIPTION
## 增加 Mock Server
- 加上 CORP_INTERNAL_API_URL 環境變數，並且在 docker-compose.yml 內加上 mock server 的設定
- 加上 mock 檔案

## 調整 pkg 公用函數
- 新增 payload 檢查
- 新增可以略過 header 及 payload 檢查的邏輯，因此可以直接塞 nil 來跳過檢查

## 新增 KeyManager 到 consent handler 內
- 調整測試程式