### PR TITLE
調整啟動時輸出驗證 OAuth Server Metadata 的 public key JWK 格式

### DIFF
--- a/corp104/cmd/server/handler_oauth2_factory.go
+++ b/corp104/cmd/server/handler_oauth2_factory.go
@@ -254,7 +254,9 @@ func initOAuthServerMetadataJWKSAndStrategy(c *config.Config) jwk.JWTStrategy {
 	pubY, _ := base64.RawURLEncoding.DecodeString(pubKeyInfo["y"])
 	derBytes, _ := x509.MarshalPKIXPublicKey(&ecdsa.PublicKey{Curve: elliptic.P256(), X: new(big.Int).SetBytes(pubX), Y: new(big.Int).SetBytes(pubY)})
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: derBytes})
-	c.GetLogger().Infof("JSON Web Key used to verify oauth server metadata\n\n%s\n\n%s", mataPubKeyBytes, pemBytes)
+	c.GetLogger().Infoln("JSON Web Key used to verify oauth server metadata")
+	c.GetLogger().Infoln(strings.Replace(string(mataPubKeyBytes), `"`, `'`, -1))
+	c.GetLogger().Infoln(string(pemBytes))
 
 	// 建立 OAuth2 authorization server metadata strategy
 	metadataStrategy, err := jwk.NewES256JWTStrategy(c.Context().KeyManager, oauth2.OAuthServerMetadataKeyName)


### PR DESCRIPTION
## 調整項目
1. 啟動時輸出的 JWK 資訊拆成三行顯示
2. JWK 的欄位改用單引號括起

```
hydra_1          | time="2018-11-09T10:37:25Z" level=info msg="JSON Web Key used to verify oauth server metadata"
hydra_1          | time="2018-11-09T10:37:25Z" level=info msg="{'use':'sig','kty':'EC','kid':'public:fc9250f6-9067-4769-a359-106460d63228','crv':'P-256','alg':'ES256','x':'EOm3Yk3YlEFKKOfK1uVXUYwQrxp9qfqKxel6SGl1Cyw','y':'fgnHV7HrmpW4euOX_QiZImKD2JP0v1X55eBRLWuzWOI'}"
hydra_1          | time="2018-11-09T10:37:25Z" level=info msg="-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEOm3Yk3YlEFKKOfK1uVXUYwQrxp9\nqfqKxel6SGl1Cyx+CcdXseualbh645f9CJkiYoPYk/S/Vfnl4FEta7NY4g==\n-----END PUBLIC KEY-----\n"
```