### PR TITLE
調整 OAuth Server Metadata 的 end_session_endpoint 路徑

### DIFF
--- a/corp104/oauth2/handler.go
+++ b/corp104/oauth2/handler.go
@@ -62,6 +62,8 @@ const (
 	CheckSessionPath = "/check-session"
 	ResourceSetPath  = "/resource-set"
 
+	EndSessionPath = "/oauth2/auth/sessions/login/revoke"
+
 	OAuthServerMetadataKeyName = "oauth.server-metadata"
 )
 
@@ -250,7 +252,7 @@ func (h *Handler) WellKnownHandler(w http.ResponseWriter, r *http.Request, _ htt
 		RegistrationEndpoint: strings.TrimRight(h.IssuerURL, "/") + client.ClientsHandlerPath,
 		RevocationEndpoint:   strings.TrimRight(h.IssuerURL, "/") + RevocationPath,
 		CheckSessionIFrame:   strings.TrimRight(h.IssuerURL, "/") + CheckSessionPath,
-		EndSessionEndpoint:								 strings.TrimRight(h.IssuerURL, "/") + DefaultLogoutPath,
+		EndSessionEndpoint:								 strings.TrimRight(h.IssuerURL, "/") + EndSessionPath,
 		ScopesSupported:                   				 scopesSupported,
 		ResponseTypes:                     				 []string{"id_token", "token"},
 		GrantTypesSupported:               				 []string{"implicit", "urn:ietf:params:oauth:grant-type:token-exchange"},

--- a/corp104/oauth2/handler_test.go
+++ b/corp104/oauth2/handler_test.go
@@ -393,7 +393,7 @@ func TestHandlerWellKnown(t *testing.T) {
 		RegistrationEndpoint:              				 strings.TrimRight(h.IssuerURL, "/") + client.ClientsHandlerPath,
 		RevocationEndpoint:								 strings.TrimRight(h.IssuerURL, "/") + oauth2.RevocationPath,
 		CheckSessionIFrame:								 strings.TrimRight(h.IssuerURL, "/") + oauth2.CheckSessionPath,
-		EndSessionEndpoint:								 strings.TrimRight(h.IssuerURL, "/") + oauth2.DefaultLogoutPath,
+		EndSessionEndpoint:								 strings.TrimRight(h.IssuerURL, "/") + oauth2.EndSessionPath,
 		ScopesSupported:                   				 []string{"openid"},
 		ResponseTypes:                     				 []string{"id_token", "token"},
 		GrantTypesSupported:               				 []string{"implicit", "urn:ietf:params:oauth:grant-type:token-exchange"},


### PR DESCRIPTION
## 調整項目
原來的 path `/logout` 指向的是 logout page，調整為真正做 logout 的 path `/oauth2/auth/sessions/login/revoke`