### PR TITLE
CORS 調整

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -192,6 +192,23 @@
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:9ab1b1c637d7c8f49e39d8538a650d7eb2137b076790cff69d160823b505964c"
+  name = "github.com/gobwas/glob"
+  packages = [
+    ".",
+    "compiler",
+    "match",
+    "syntax",
+    "syntax/ast",
+    "syntax/lexer",
+    "util/runes",
+    "util/strings",
+  ]
+  pruneopts = ""
+  revision = "5ccd90ef52e1e632236f7326478d4faa74f99438"
+  version = "v0.2.3"
+
+[[projects]]
   branch = "master"
   digest = "1:046a699004979280a3644e97d4758e832e81d70910974f1ff8728cf83a632a24"
   name = "github.com/goincremental/negroni-sessions"
@@ -997,6 +1014,7 @@
     "github.com/go-playground/validator",
     "github.com/go-resty/resty",
     "github.com/go-sql-driver/mysql",
+    "github.com/gobwas/glob",
     "github.com/goincremental/negroni-sessions",
     "github.com/goincremental/negroni-sessions/cookiestore",
     "github.com/golang/mock/gomock",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -177,3 +177,7 @@
 [[constraint]]
   name = "github.com/go-playground/validator"
   version = "9.24.0"
+
+[[constraint]]
+  name = "github.com/gobwas/glob"
+  version = "0.2.3"

--- a/corp104/client/sdk_test.go
+++ b/corp104/client/sdk_test.go
@@ -114,7 +114,9 @@ func TestClientSDK(t *testing.T) {
 	handler := client.NewHandler(manager, herodot.NewJSONWriter(nil), []string{"foo", "bar"}, []string{"public"}, keyManager, "http://localhost:4444", "jwk.offline")
 
 	router := httprouter.New()
-	handler.SetRoutes(router)
+	handler.SetRoutes(router, router, func(h http.Handler) http.Handler {
+		return h
+	})
 	n := negroni.New()
 	store := cookiestore.New([]byte("secret"))
 	store.Options(sessions.Options{
@@ -207,14 +209,8 @@ func TestClientSDK(t *testing.T) {
 					require.EqualValues(t, updateClient.SoftwareVersion, c.SoftwareVersion)
 				})
 
-				t.Run("case=delete client with invalid client credentials", func(t *testing.T) {
-					response, err := c.DeleteOAuth2Client(createClient.ClientId, "wrong")
-					require.NoError(t, err)
-					require.EqualValues(t, http.StatusUnauthorized, response.StatusCode)
-				})
-
-				t.Run("case=delete client with valid client credentials", func(t *testing.T) {
-					response, err := c.DeleteOAuth2Client(createClient.ClientId, clientSecret)
+				t.Run("case=delete client", func(t *testing.T) {
+					response, err := c.DeleteOAuth2Client(createClient.ClientId)
 					require.NoError(t, err)
 					require.EqualValues(t, http.StatusNoContent, response.StatusCode)
 				})

--- a/corp104/cmd/cli/handler_client.go
+++ b/corp104/cmd/cli/handler_client.go
@@ -161,9 +161,7 @@ func (h *ClientHandler) DeleteClient(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	clientSecret, _ := cmd.Flags().GetString("secret")
-
-	response, err := m.DeleteOAuth2Client(args[0], clientSecret)
+	response, err := m.DeleteOAuth2Client(args[0])
 	checkResponse(response, err, http.StatusNoContent)
 	fmt.Println("OAuth2 client deleted.")
 }

--- a/corp104/cmd/clients_delete.go
+++ b/corp104/cmd/clients_delete.go
@@ -22,7 +22,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // clientsDeleteCmd represents the delete command
@@ -32,12 +31,10 @@ var clientsDeleteCmd = &cobra.Command{
 	Long: `This command deletes one or more OAuth 2.0 Clients by their respective IDs.
 
 Example:
-  hydra clients delete client-1 --secret secret`,
+  hydra clients delete client-1`,
 	Run: cmdHandler.Clients.DeleteClient,
 }
 
 func init() {
 	clientsCmd.AddCommand(clientsDeleteCmd)
-	clientsDeleteCmd.Flags().String("secret", os.Getenv("OAUTH2_CLIENT_SECRET"), "Use the provided OAuth 2.0 Client Secret, defaults to environment variable OAUTH2_CLIENT_SECRET")
-	clientsDeleteCmd.MarkFlagRequired("secret")
 }

--- a/corp104/cmd/root_test.go
+++ b/corp104/cmd/root_test.go
@@ -109,7 +109,7 @@ func TestExecute(t *testing.T) {
 		{args: []string{"clients", "put", "--endpoint", frontend, "--id", "foobarbaz", "--secret", "secret", "--name", "foobarbaz", "-g", "urn:ietf:params:oauth:grant-type:jwt-bearer", "--client-uri", "http://foobarbaz.org", "--contacts", "admin@foobarbaz.org", "--software-id", "4d51529c-37cd-424c-ba19-cba742d60903", "--software-version", "0.0.1", "--token-endpoint-auth-method", "private_key_jwt", "--jwks", `{"keys":[{"use":"sig","kty":"EC","kid":"public:89b940e8-a16f-48ce-a238-b52d7e252634","crv":"P-256","alg":"ES256","x":"6yi0V0cyxGVc5fEiu2U2PuZr4TxavTguccdcco1XyuA","y":"kX_biw0hYHyt1qaVP4EbP7WScIu9QyPK0Aj3fXpBRCg"}]}`, "--signing-jwk", `{"use":"sig","kty":"EC","kid":"private:89b940e8-a16f-48ce-a238-b52d7e252634","crv":"P-256","alg":"ES256","x":"6yi0V0cyxGVc5fEiu2U2PuZr4TxavTguccdcco1XyuA","y":"kX_biw0hYHyt1qaVP4EbP7WScIu9QyPK0Aj3fXpBRCg","d":"G4ExPHksANQZgLJzElHUGL43The7h0AKJE69qrgcZRo"}`, "--auth-public-jwk", "env:OFFLINE_PUBLIC_KEY", "--user", "foo.bar", "--pwd", "secret"}},
 		{args: []string{"clients", "commit", "--endpoint", frontend, "--id", "foobarbaz", "--commit-code", "env:COMMIT_CODE"}},
 		{args: []string{"clients", "get", "--endpoint", frontend, "foobarbaz", "--secret", "secret"}},
-		{args: []string{"clients", "delete", "--endpoint", frontend, "foobarbaz", "--secret", "secret"}},
+		{args: []string{"clients", "delete", "--endpoint", backend, "foobarbaz"}},
 		{args: []string{"keys", "create", "foo", "--endpoint", backend, "-a", "HS256"}},
 		{args: []string{"keys", "get", "--endpoint", backend, "foo"}},
 		//{args: []string{"keys", "rotate", "--endpoint", backend, "foo"}},

--- a/corp104/cmd/server/handler.go
+++ b/corp104/cmd/server/handler.go
@@ -283,9 +283,9 @@ func (h *Handler) RegisterRoutes(frontend, backend *httprouter.Router) {
 	h.initOfflineJWK()
 
 	// Set up handlers
-	h.Clients = newClientHandler(c, frontend, clientsManager)
-	h.Keys = newJWKHandler(c, frontend, backend)
-	h.Consent = newConsentHandler(c, frontend, backend)
+	h.Clients = newClientHandler(c, frontend, backend, clientsManager, oauth2Provider)
+	h.Keys = newJWKHandler(c, frontend, backend, oauth2Provider, clientsManager)
+	h.Consent = newConsentHandler(c, frontend, backend, oauth2Provider, clientsManager)
 	h.OAuth2 = newOAuth2Handler(c, frontend, backend, ctx.ConsentManager, oauth2Provider, clientsManager, ctx.ResourceManager)
 	h.Resources = newResourceHandler(c, frontend, ctx.ResourceManager)
 	_ = newHealthHandler(c, frontend)

--- a/corp104/cmd/server/handler_oauth2_factory.go
+++ b/corp104/cmd/server/handler_oauth2_factory.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ory/fosite/compose"
 	foauth2 "github.com/ory/fosite/handler/oauth2"
 	"github.com/ory/fosite/handler/openid"
+	"github.com/ory/go-convenience/corsx"
 	"github.com/ory/go-convenience/stringslice"
 	"github.com/ory/herodot"
 	"github.com/ory/hydra/corp104/client"
@@ -224,7 +225,7 @@ func newOAuth2Handler(c *config.Config, frontend, backend *httprouter.Router, cm
 		ResourceManager:             rm,
 	}
 
-	corsMiddleware := newCORSMiddleware(viper.GetString("CORS_ENABLED") == "true", c, o.IntrospectToken, clm.GetConcreteClient)
+	corsMiddleware := newCORSMiddleware(viper.GetString("CORS_ENABLED") == "true", c, corsx.ParseOptions(), o.IntrospectToken, clm.GetConcreteClient)
 	handler.SetRoutes(frontend, backend, corsMiddleware)
 	return handler
 }

--- a/corp104/cmd/server/helper_cors.go
+++ b/corp104/cmd/server/helper_cors.go
@@ -23,18 +23,19 @@ package server
 import (
 	"context"
 	"net/http"
+	"strings"
+
+	"github.com/gobwas/glob"
+	"github.com/rs/cors"
 
 	"github.com/ory/fosite"
-	"github.com/ory/go-convenience/corsx"
-	"github.com/ory/go-convenience/stringslice"
 	"github.com/ory/hydra/corp104/client"
 	"github.com/ory/hydra/corp104/config"
 	"github.com/ory/hydra/corp104/oauth2"
-	"github.com/rs/cors"
 )
 
 func newCORSMiddleware(
-	enable bool, c *config.Config,
+	enable bool, c *config.Config, po cors.Options,
 	o func(ctx context.Context, token string, tokenType fosite.TokenType, session fosite.Session, scope ...string) (fosite.TokenType, fosite.AccessRequester, error),
 	clm func(ctx context.Context, id string) (*client.Client, error),
 ) func(h http.Handler) http.Handler {
@@ -45,7 +46,27 @@ func newCORSMiddleware(
 	}
 
 	c.GetLogger().Info("Enabled CORS")
-	po := corsx.ParseOptions()
+	var patterns []glob.Glob
+	for _, o := range po.AllowedOrigins {
+		g, err := glob.Compile(strings.ToLower(o), '.')
+		if err != nil {
+			c.GetLogger().WithError(err).Fatalf("Unable to parse cors origin: %s", o)
+		}
+		patterns = append(patterns, g)
+	}
+
+	var alwaysAllow bool
+	for _, o := range po.AllowedOrigins {
+		if o == "*" {
+			alwaysAllow = true
+			break
+		}
+	}
+
+	if enable && len(po.AllowedOrigins) == 0 {
+		alwaysAllow = true
+	}
+
 	options := cors.Options{
 		AllowedOrigins:     po.AllowedOrigins,
 		AllowedMethods:     po.AllowedMethods,
@@ -56,8 +77,15 @@ func newCORSMiddleware(
 		OptionsPassthrough: po.OptionsPassthrough,
 		Debug:              po.Debug,
 		AllowOriginRequestFunc: func(r *http.Request, origin string) bool {
-			if stringslice.Has(po.AllowedOrigins, origin) {
+			if alwaysAllow {
 				return true
+			}
+
+			origin = strings.ToLower(origin)
+			for _, p := range patterns {
+				if p.Match(origin) {
+					return true
+				}
 			}
 
 			username, _, ok := r.BasicAuth()
@@ -81,8 +109,29 @@ func newCORSMiddleware(
 				return false
 			}
 
-			if stringslice.Has(cl.AllowedCORSOrigins, origin) {
+			if alwaysAllow {
 				return true
+			}
+
+			for _, p := range cl.AllowedCORSOrigins {
+				if p == "*" {
+					return true
+				}
+			}
+
+			var clientPatterns []glob.Glob
+			for _, o := range cl.AllowedCORSOrigins {
+				g, err := glob.Compile(strings.ToLower(o), '.')
+				if err != nil {
+					return false
+				}
+				clientPatterns = append(patterns, g)
+			}
+
+			for _, p := range clientPatterns {
+				if p.Match(origin) {
+					return true
+				}
 			}
 
 			return false

--- a/corp104/cmd/server/helper_cors_test.go
+++ b/corp104/cmd/server/helper_cors_test.go
@@ -29,11 +29,13 @@ import (
 	"testing"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/rs/cors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ory/fosite"
 	"github.com/ory/hydra/corp104/client"
 	"github.com/ory/hydra/corp104/config"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCORSMiddleware(t *testing.T) {
@@ -52,14 +54,14 @@ func TestCORSMiddleware(t *testing.T) {
 	}{
 		{
 			d:            "should ignore when disabled",
-			mw:           newCORSMiddleware(false, nil, nil, nil),
+			mw:           newCORSMiddleware(false, nil, cors.Options{AllowedOrigins: []string{"http://not-test-domain.com"}}, nil, nil),
 			code:         204,
 			header:       http.Header{},
 			expectHeader: http.Header{},
 		},
 		{
 			d: "should reject when basic auth but client does not exist",
-			mw: newCORSMiddleware(true, c, nil, func(ctx context.Context, id string) (*client.Client, error) {
+			mw: newCORSMiddleware(true, c, cors.Options{AllowedOrigins: []string{"http://not-test-domain.com"}}, nil, func(ctx context.Context, id string) (*client.Client, error) {
 				return nil, errors.New("")
 			}),
 			code:         204,
@@ -68,7 +70,7 @@ func TestCORSMiddleware(t *testing.T) {
 		},
 		{
 			d: "should reject when basic auth client exists but origin not allowed",
-			mw: newCORSMiddleware(true, c, nil, func(ctx context.Context, id string) (*client.Client, error) {
+			mw: newCORSMiddleware(true, c, cors.Options{AllowedOrigins: []string{"http://not-test-domain.com"}}, nil, func(ctx context.Context, id string) (*client.Client, error) {
 				return &client.Client{AllowedCORSOrigins: []string{"http://not-foobar.com"}}, nil
 			}),
 			code:         204,
@@ -77,7 +79,7 @@ func TestCORSMiddleware(t *testing.T) {
 		},
 		{
 			d: "should accept when basic auth client exists and origin allowed",
-			mw: newCORSMiddleware(true, c, nil, func(ctx context.Context, id string) (*client.Client, error) {
+			mw: newCORSMiddleware(true, c, cors.Options{AllowedOrigins: []string{"http://not-test-domain.com"}}, nil, func(ctx context.Context, id string) (*client.Client, error) {
 				return &client.Client{AllowedCORSOrigins: []string{"http://foobar.com"}}, nil
 			}),
 			code:         204,
@@ -85,8 +87,44 @@ func TestCORSMiddleware(t *testing.T) {
 			expectHeader: http.Header{"Vary": {"Origin"}, "Access-Control-Allow-Origin": {"http://foobar.com"}},
 		},
 		{
+			d: "should accept when basic auth client exists and origin (with partial wildcard) is allowed per client",
+			mw: newCORSMiddleware(true, c, cors.Options{AllowedOrigins: []string{"http://not-test-domain.com"}}, nil, func(ctx context.Context, id string) (*client.Client, error) {
+				return &client.Client{AllowedCORSOrigins: []string{"http://*.foobar.com"}}, nil
+			}),
+			code:         204,
+			header:       http.Header{"Origin": {"http://foo.foobar.com"}, "Authorization": {"Basic Zm9vOmJhcg=="}},
+			expectHeader: http.Header{"Vary": {"Origin"}, "Access-Control-Allow-Origin": {"http://foo.foobar.com"}},
+		},
+		{
+			d: "should accept when basic auth client exists and origin (with full wildcard) is allowed globally",
+			mw: newCORSMiddleware(true, c, cors.Options{AllowedOrigins: []string{"*"}}, nil, func(ctx context.Context, id string) (*client.Client, error) {
+				return &client.Client{AllowedCORSOrigins: []string{"http://barbar.com"}}, nil
+			}),
+			code:         204,
+			header:       http.Header{"Origin": {"*"}, "Authorization": {"Basic Zm9vOmJhcg=="}},
+			expectHeader: http.Header{"Vary": {"Origin"}, "Access-Control-Allow-Origin": {"*"}},
+		},
+		{
+			d: "should accept when basic auth client exists and origin (with partial wildcard) is allowed globally",
+			mw: newCORSMiddleware(true, c, cors.Options{AllowedOrigins: []string{"http://*.foobar.com"}}, nil, func(ctx context.Context, id string) (*client.Client, error) {
+				return &client.Client{AllowedCORSOrigins: []string{"http://barbar.com"}}, nil
+			}),
+			code:         204,
+			header:       http.Header{"Origin": {"http://foo.foobar.com"}, "Authorization": {"Basic Zm9vOmJhcg=="}},
+			expectHeader: http.Header{"Vary": {"Origin"}, "Access-Control-Allow-Origin": {"http://foo.foobar.com"}},
+		},
+		{
+			d: "should accept when basic auth client exists and origin (with full wildcard) allowed per client",
+			mw: newCORSMiddleware(true, c, cors.Options{AllowedOrigins: []string{"http://not-test-domain.com"}}, nil, func(ctx context.Context, id string) (*client.Client, error) {
+				return &client.Client{AllowedCORSOrigins: []string{"*"}}, nil
+			}),
+			code:         204,
+			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {"Basic Zm9vOmJhcg=="}},
+			expectHeader: http.Header{"Vary": {"Origin"}, "Access-Control-Allow-Origin": {"http://foobar.com"}},
+		},
+		{
 			d: "should fail when token introspection fails",
-			mw: newCORSMiddleware(true, c, func(ctx context.Context, token string, tokenType fosite.TokenType, session fosite.Session, scope ...string) (fosite.TokenType, fosite.AccessRequester, error) {
+			mw: newCORSMiddleware(true, c, cors.Options{AllowedOrigins: []string{"http://not-test-domain.com"}}, func(ctx context.Context, token string, tokenType fosite.TokenType, session fosite.Session, scope ...string) (fosite.TokenType, fosite.AccessRequester, error) {
 				return "", nil, errors.New("")
 			}, func(ctx context.Context, id string) (*client.Client, error) {
 				return &client.Client{AllowedCORSOrigins: []string{"http://foobar.com"}}, nil
@@ -97,7 +135,7 @@ func TestCORSMiddleware(t *testing.T) {
 		},
 		{
 			d: "should fail when token introspection fails",
-			mw: newCORSMiddleware(true, c, func(ctx context.Context, token string, tokenType fosite.TokenType, session fosite.Session, scope ...string) (fosite.TokenType, fosite.AccessRequester, error) {
+			mw: newCORSMiddleware(true, c, cors.Options{AllowedOrigins: []string{"http://not-test-domain.com"}}, func(ctx context.Context, token string, tokenType fosite.TokenType, session fosite.Session, scope ...string) (fosite.TokenType, fosite.AccessRequester, error) {
 				if token != "1234" {
 					return "", nil, errors.New("")
 				}
@@ -113,7 +151,7 @@ func TestCORSMiddleware(t *testing.T) {
 			expectHeader: http.Header{"Vary": {"Origin"}, "Access-Control-Allow-Origin": {"http://foobar.com"}},
 		},
 	} {
-		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
+		t.Run(fmt.Sprintf("case=%d/description=%s", k, tc.d), func(t *testing.T) {
 			req, err := http.NewRequest("GET", "http://foobar.com/", nil)
 			require.NoError(t, err)
 			for k := range tc.header {

--- a/corp104/consent/handler_test.go
+++ b/corp104/consent/handler_test.go
@@ -79,7 +79,9 @@ func TestLogout(t *testing.T) {
 	r.Handle("GET", "/logout", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	})
 
-	h.SetRoutes(r, r)
+	h.SetRoutes(r, r, func(h http.Handler) http.Handler {
+		return h
+	})
 	ts := httptest.NewServer(n)
 	defer ts.Close()
 

--- a/corp104/jwk/handler_test.go
+++ b/corp104/jwk/handler_test.go
@@ -52,7 +52,9 @@ func init() {
 	h.Manager.AddKeySet(context.TODO(), IDTokenKeyName, IDKS)
 	offlineKS, _ := testGenerator.Generate("test-offline-jwk", "sig")
 	h.Manager.AddKeySet(context.TODO(), "jwk.offline", offlineKS)
-	h.SetRoutes(router, router)
+	h.SetRoutes(router, router, func(h http.Handler) http.Handler {
+		return h
+	})
 	testServer = httptest.NewServer(router)
 }
 

--- a/corp104/jwk/sdk_test.go
+++ b/corp104/jwk/sdk_test.go
@@ -41,7 +41,9 @@ func TestJWKSDK(t *testing.T) {
 		Manager: manager,
 		H:       herodot.NewJSONWriter(nil),
 	}
-	h.SetRoutes(router, router)
+	h.SetRoutes(router, router, func(h http.Handler) http.Handler {
+		return h
+	})
 	server := httptest.NewServer(router)
 
 	client := hydra.NewJsonWebKeyApiWithBasePath(server.URL)

--- a/corp104/oauth2/handler.go
+++ b/corp104/oauth2/handler.go
@@ -198,14 +198,18 @@ type FlushInactiveOAuth2TokensRequest struct {
 }
 
 func (h *Handler) SetRoutes(frontend, backend *httprouter.Router, corsMiddleware func(http.Handler) http.Handler) {
+	frontend.Handler("OPTIONS", TokenPath, corsMiddleware(http.HandlerFunc(h.handleOptions)))
 	frontend.Handler("POST", TokenPath, corsMiddleware(http.HandlerFunc(h.TokenHandler)))
 	frontend.GET(AuthPath, h.AuthHandler)
 	frontend.POST(AuthPath, h.AuthHandler)
 	frontend.GET(DefaultConsentPath, h.DefaultConsentHandler)
 	frontend.GET(DefaultErrorPath, h.DefaultErrorHandler)
 	frontend.GET(DefaultLogoutPath, h.DefaultLogoutHandler)
+	frontend.Handler("OPTIONS", RevocationPath, corsMiddleware(http.HandlerFunc(h.handleOptions)))
 	frontend.Handler("POST", RevocationPath, corsMiddleware(http.HandlerFunc(h.RevocationHandler)))
-	frontend.GET(WellKnownPath, h.WellKnownHandler)
+	frontend.Handler("OPTIONS", WellKnownPath, corsMiddleware(http.HandlerFunc(h.handleOptions)))
+	frontend.Handler("GET", WellKnownPath, corsMiddleware(http.HandlerFunc(h.WellKnownHandler)))
+	frontend.Handler("OPTIONS", UserinfoPath, corsMiddleware(http.HandlerFunc(h.handleOptions)))
 	frontend.Handler("GET", UserinfoPath, corsMiddleware(http.HandlerFunc(h.UserinfoHandler)))
 	frontend.Handler("POST", UserinfoPath, corsMiddleware(http.HandlerFunc(h.UserinfoHandler)))
 
@@ -230,7 +234,7 @@ func (h *Handler) SetRoutes(frontend, backend *httprouter.Router, corsMiddleware
 //       200: wellKnown
 //       401: genericError
 //       500: genericError
-func (h *Handler) WellKnownHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func (h *Handler) WellKnownHandler(w http.ResponseWriter, r *http.Request) {
 	claimsSupported := []string{"sub"}
 	if h.ClaimsSupported != "" {
 		claimsSupported = append(claimsSupported, strings.Split(h.ClaimsSupported, ",")...)
@@ -719,3 +723,7 @@ func (h *Handler) writeAuthorizeError(w http.ResponseWriter, ar fosite.Authorize
 
 	h.OAuth2.WriteAuthorizeError(w, ar, err)
 }
+
+// This function will not be called, OPTIONS request will be handled by cors
+// this is just a placeholder.
+func (h *Handler) handleOptions(w http.ResponseWriter, r *http.Request) {}

--- a/corp104/oauth2/oauth2_auth_code_test.go
+++ b/corp104/oauth2/oauth2_auth_code_test.go
@@ -49,8 +49,8 @@ import (
 	"github.com/ory/hydra/corp104/consent"
 	"github.com/ory/hydra/corp104/jwk"
 	. "github.com/ory/hydra/corp104/oauth2"
-	"github.com/ory/hydra/pkg"
 	"github.com/ory/hydra/corp104/sdk/go/corp104/swagger"
+	"github.com/ory/hydra/pkg"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -102,10 +102,10 @@ func _TestAuthCodeWithDefaultStrategy(t *testing.T) {
 		s foauth2.CoreStrategy
 	}{
 		/*
-		{
-			d: "opaque",
-			s: oauth2OpqaueStrategy,
-		},
+			{
+				d: "opaque",
+				s: oauth2OpqaueStrategy,
+			},
 		*/
 		{
 			d: "jwt",
@@ -203,7 +203,9 @@ func _TestAuthCodeWithDefaultStrategy(t *testing.T) {
 
 					apiHandler := consent.NewHandler(herodot.NewJSONWriter(l), cm, cookieStore, "", jm)
 					apiRouter := httprouter.New()
-					apiHandler.SetRoutes(apiRouter, apiRouter)
+					apiHandler.SetRoutes(apiRouter, apiRouter, func(h http.Handler) http.Handler {
+						return h
+					})
 					api := httptest.NewServer(apiRouter)
 
 					client := hc.Client{

--- a/corp104/sdk/go/corp104/sdk_api.go
+++ b/corp104/sdk/go/corp104/sdk_api.go
@@ -49,7 +49,7 @@ type OAuth2API interface {
 	GetConsentRequest(challenge string) (*swagger.ConsentRequest, *swagger.APIResponse, error)
 
 	PutOAuth2Client(body swagger.OAuth2Client, signingJwk *swagger.JsonWebKey, authSrvPubJwk *swagger.JsonWebKey) (*swagger.PutClientResponse, *swagger.APIResponse, error)
-	DeleteOAuth2Client(id, secret string) (*swagger.APIResponse, error)
+	DeleteOAuth2Client(id string) (*swagger.APIResponse, error)
 	GetOAuth2Client(id, secret string) (*swagger.OAuth2Client, *swagger.APIResponse, error)
 	GetWellKnown(*swagger.JsonWebKey) (*swagger.WellKnown, *swagger.APIResponse, error)
 	IntrospectOAuth2Token(token string, scope string) (*swagger.OAuth2TokenIntrospection, *swagger.APIResponse, error)

--- a/corp104/sdk/go/corp104/swagger/docs/OAuth2Api.md
+++ b/corp104/sdk/go/corp104/swagger/docs/OAuth2Api.md
@@ -135,15 +135,14 @@ Delete an existing OAuth 2.0 Client by its ID.  OAuth 2.0 clients are used to pe
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **string**| The id of the OAuth 2.0 Client. | 
- **secret** | **string**| The secret of the OAuth 2.0 Client. |
-
+ 
 ### Return type
 
 void (empty response body)
 
 ### Authorization
 
-Require client credentials
+No authorization required
 
 ### HTTP request headers
 

--- a/corp104/sdk/go/corp104/swagger/o_auth2_api.go
+++ b/corp104/sdk/go/corp104/swagger/o_auth2_api.go
@@ -264,18 +264,17 @@ func (a OAuth2Api) PutOAuth2Client(body OAuth2Client, signingJwk *JsonWebKey, au
  * Delete an existing OAuth 2.0 Client by its ID.  OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities. To manage ORY Hydra, you will need an OAuth 2.0 Client as well. Make sure that this endpoint is well protected and only callable by first-party components.
  *
  * @param id The id of the OAuth 2.0 Client.
- * @param secret The secret of the OAuth 2.0 Client.
  * @return void
  */
-func (a OAuth2Api) DeleteOAuth2Client(id, secret string) (*APIResponse, error) {
-	if id == "" || secret == "" {
-		return nil, errors.New("require client credentials")
+func (a OAuth2Api) DeleteOAuth2Client(id string) (*APIResponse, error) {
+	if id == "" {
+		return nil, errors.New("require client ID")
 	}
 
 	var localVarHttpMethod = strings.ToUpper("Delete")
 	// create path and map variables
 	localVarPath := a.Configuration.BasePath + "/clients/{id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", fmt.Sprintf("%v", id), -1)
+	localVarPath = strings.Replace(localVarPath, "{id}", fmt.Sprintf("%v", id), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -287,9 +286,6 @@ func (a OAuth2Api) DeleteOAuth2Client(id, secret string) (*APIResponse, error) {
 	for key := range a.Configuration.DefaultHeader {
 		localVarHeaderParams[key] = a.Configuration.DefaultHeader[key]
 	}
-
-	// set Authorization header
-	localVarHeaderParams["Authorization"] = "Basic " + pkg.BasicAuth(id, secret)
 
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/json"}

--- a/docker-compose-twoc.yml
+++ b/docker-compose-twoc.yml
@@ -55,9 +55,16 @@ services:
       - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
       - DISABLE_CONSENT_FLOW=1
       - BY_PASS_ROUTES=/clients
-      - CORS_ENABLED=1
+      - DISABLE_TELEMETRY=1
+      - CORS_ENABLED=true
+#      - CORS_ALLOWED_ORIGINS=*
+      - CORS_ALLOWED_METHODS=GET,POST,PUT,OPTIONS
+      - CORS_ALLOWED_CREDENTIALS=true
+#      - CORS_MAX_AGE=864000
+      - CORS_DEBUG=true
       - CORP_INTERNAL_API_URL=http://mock-dep:8080
       - AD_LOGIN_URL=http://mock-dep:8080/ad/login
+      - TEST_MODE=1
     restart: on-failure
 
   hydra:
@@ -88,12 +95,19 @@ services:
       - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
       - DISABLE_CONSENT_FLOW=1
       - BY_PASS_ROUTES=/clients,/forgotPassword,/resetPassword
-      - CORS_ENABLED=1
+      - DISABLE_TELEMETRY=1
+      - CORS_ENABLED=true
+#      - CORS_ALLOWED_ORIGINS=*
+      - CORS_ALLOWED_METHODS=GET,POST,PUT,OPTIONS
+      - CORS_ALLOWED_CREDENTIALS=true
+#      - CORS_MAX_AGE=0
+      - CORS_DEBUG=true
       - CORP_INTERNAL_API_URL=http://mock-dep:8080
       - AD_LOGIN_URL=http://mock-dep:8080/ad/login
       - GRAPHQL_API_URL=http://mbs:4000
       - EMAIL_SERVICE_URL=http://mta:10025
       - RESET_PASSWORD_ROUTE=http://localhost:4200/reset-password
+      - TEST_MODE=1
     restart: on-failure
 
   consent:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,12 +63,19 @@ services:
       - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
       - DISABLE_CONSENT_FLOW=1
       - BY_PASS_ROUTES=/clients,/forgotPassword,/resetPassword
-      - CORS_ENABLED=1
+      - DISABLE_TELEMETRY=1
+      - CORS_ENABLED=true
+#      - CORS_ALLOWED_ORIGINS=*
+      - CORS_ALLOWED_METHODS=GET,POST,PUT,OPTIONS
+      - CORS_ALLOWED_CREDENTIALS=true
+#      - CORS_MAX_AGE=0
+      - CORS_DEBUG=true
       - CORP_INTERNAL_API_URL=http://mock-dep:8080
       - AD_LOGIN_URL=http://mock-dep:8080/ad/login
       - GRAPHQL_API_URL=http://mbs:4000
       - EMAIL_SERVICE_URL=http://mta:10025
       - RESET_PASSWORD_ROUTE=http://localhost:4200/reset-password
+      - TEST_MODE=1
     restart: on-failure
 
 #  consent:

--- a/mock-dep/mock_server.go
+++ b/mock-dep/mock_server.go
@@ -62,7 +62,7 @@ func StartMockServer() error {
 	}
 
 	// waiting for the server to start
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	return nil
 }


### PR DESCRIPTION
## Clients Handler 調整
1. GET /clients  改為 backend router
2. Delete /clients/{id}  改為 backend router 並調整 service、SDK、doc
3. PUT /clients 增加 CORS 支援

## JWK Handler 調整，增加 CORS 支援 
1. GET /jwks.json 增加 CORS 支援

## Consent Handler 調整，增加 CORS 支援 
1.  GET /oauth2/auth/requests/login/:challenge
2. POST /oauth2/auth/requests/login/:challenge/accept
3. POST /oauth2/auth/requests/login/:challenge/reject
4. GET /oauth2/auth/sessions/login/revoke
5. POST /idp
6. POST /forgotPassword
7. POST /resetPassword

## OAuth2 Handler 調整，增加 CORS 支援 
1. POST /token
2. POST /revoke
3. GET /.well-known/oauth-authorization-server
4. GET /userinfo

## docker-compose.yml 調整
1. 增加  CORS 設定
2. 增加 DISABLE_TELEMETRY=1，不傳送資訊給 hydra team
3. 增加 TEST_MODE=1
