### PR TITLE
public client 的 token_endpoint_auth_method 調整為 private_key_jwt+session

### DIFF
--- a/corp104/client/client.go
+++ b/corp104/client/client.go
@@ -207,7 +207,7 @@ func (c *Client) GetOwner() string {
 }
 
 func (c *Client) IsPublic() bool {
-	return c.TokenEndpointAuthMethod == "none" || c.TokenEndpointAuthMethod == "session"
+	return c.TokenEndpointAuthMethod == "none" || c.TokenEndpointAuthMethod == "private_key_jwt+session"
 }
 
 func (c *Client) GetJSONWebKeysURI() string {

--- a/corp104/client/client_test.go
+++ b/corp104/client/client_test.go
@@ -35,7 +35,7 @@ func TestClient(t *testing.T) {
 		ClientID:                "foo",
 		RedirectURIs:            []string{"foo"},
 		Scope:                   "foo bar",
-		TokenEndpointAuthMethod: "session",
+		TokenEndpointAuthMethod: "private_key_jwt+session",
 	}
 
 	assert.EqualValues(t, c.RedirectURIs, c.GetRedirectURIs())

--- a/corp104/client/sdk_test.go
+++ b/corp104/client/sdk_test.go
@@ -235,7 +235,7 @@ func createTestPublicClient(prefix string, pubJwk hydra.JsonWebKey) hydra.OAuth2
 		SoftwareVersion:          prefix + "0.0.1",
 		IdTokenSignedResponseAlg: "ES256",
 		RequestObjectSigningAlg:  "ES256",
-		TokenEndpointAuthMethod:  "session",
+		TokenEndpointAuthMethod:  "private_key_jwt+session",
 	}
 }
 

--- a/corp104/client/validator.go
+++ b/corp104/client/validator.go
@@ -119,8 +119,8 @@ func (v *Validator) Validate(c *Client) error {
 	}
 
 	if c.IsPublic() {
-		if c.TokenEndpointAuthMethod != "session" {
-			return errors.WithStack(fosite.ErrInvalidRequest.WithHint("Field token_endpoint_auth_method should be \"session\"."))
+		if c.TokenEndpointAuthMethod != "private_key_jwt+session" {
+			return errors.WithStack(fosite.ErrInvalidRequest.WithHint("Field token_endpoint_auth_method should be \"private_key_jwt+session\"."))
 		}
 
 		if err := v.checkRequired("redirect_uris", c.RedirectURIs); err != nil {

--- a/corp104/client/validator_test.go
+++ b/corp104/client/validator_test.go
@@ -63,7 +63,7 @@ func TestValidate(t *testing.T) {
 				SoftwareVersion:                "0.0.1",
 				IdTokenSignedResponseAlgorithm: "ES256",
 				RequestObjectSigningAlgorithm:  "ES256",
-				TokenEndpointAuthMethod:        "session",
+				TokenEndpointAuthMethod:        "private_key_jwt+session",
 			},
 			check: func(t *testing.T, c *Client) {
 				assert.NotEmpty(t, c.ClientID)

--- a/corp104/cmd/clients_put.go
+++ b/corp104/cmd/clients_put.go
@@ -53,7 +53,7 @@ Example:
      --scope "openid" \
      --id-token-signed-response-alg "ES256" \
      --request-object-signing-alg "ES256" \
-	 --token-endpoint-auth-method "session" \
+	 --token-endpoint-auth-method "private_key_jwt+session" \
      --jwks '{"keys":[{"use":"sig","kty":"EC","kid":"public:89b940e8-a16f-48ce-a238-b52d7e252634","crv":"P-256","alg":"ES256","x":"6yi0V0cyxGVc5fEiu2U2PuZr4TxavTguccdcco1XyuA","y":"kX_biw0hYHyt1qaVP4EbP7WScIu9QyPK0Aj3fXpBRCg"}]}' \
      --signing-jwk '{"use":"sig","kty":"EC","kid":"private:89b940e8-a16f-48ce-a238-b52d7e252634","crv":"P-256","alg":"ES256","x":"6yi0V0cyxGVc5fEiu2U2PuZr4TxavTguccdcco1XyuA","y":"kX_biw0hYHyt1qaVP4EbP7WScIu9QyPK0Aj3fXpBRCg","d":"G4ExPHksANQZgLJzElHUGL43The7h0AKJE69qrgcZRo"}' \
      --auth-public-jwk '{"use":"sig","kty":"EC","kid":"public:7d59b645-94e7-48c5-9f73-695b19294737","crv":"P-256","alg":"ES256","x":"zrt4vi0eIGY6iqAzpmrBqth33xl2D8R0kkp7laLqzYQ","y":"wbKUX4uBMidl840SANrfWPoTNU6YmYgYh-Aj51TrrWI"}'
@@ -88,7 +88,7 @@ func init() {
 	clientsPutCmd.Flags().StringSliceP("grant-types", "g", []string{""}, "A list of allowed grant types")
 	clientsPutCmd.Flags().StringSliceP("response-types", "r", []string{""}, "A list of allowed response types")
 	clientsPutCmd.Flags().StringSliceP("scope", "a", []string{""}, "The scope the client is allowed to request")
-	clientsPutCmd.Flags().String("token-endpoint-auth-method", "session", "Define which authentication method the client may use at the Token Endpoint. Valid values are \"private_key_jwt\" and \"session\"")
+	clientsPutCmd.Flags().String("token-endpoint-auth-method", "private_key_jwt", "Define which authentication method the client may use at the Token Endpoint. Valid values are \"private_key_jwt\" and \"session\"")
 	//clientsPutCmd.Flags().String("jwks-uri", "", "Define the URL where the JSON Web Key Set should be fetched from when performing the \"private_key_jwt\" client authentication method")
 	clientsPutCmd.Flags().String("policy-uri", "", "A URL string that points to a human-readable privacy policy document that describes how the deployment organization collects, uses, retains, and discloses personal data")
 	clientsPutCmd.Flags().String("tos-uri", "", "A URL string that points to a human-readable terms of service document for the client that describes a contractual relationship between the end-user and the client that the end-user accepts when authorizing the client")

--- a/corp104/oauth2/handler.go
+++ b/corp104/oauth2/handler.go
@@ -262,7 +262,7 @@ func (h *Handler) WellKnownHandler(w http.ResponseWriter, r *http.Request) {
 		ScopesSupported:                   scopesSupported,
 		ResponseTypes:                     []string{"id_token", "token"},
 		GrantTypesSupported:               []string{"implicit", "urn:ietf:params:oauth:grant-type:jwt-bearer"},
-		TokenEndpointAuthMethodsSupported: []string{"private_key_jwt"},
+		TokenEndpointAuthMethodsSupported: []string{"private_key_jwt", "private_key_jwt+session"},
 		TokenEndpointAuthSigningAlgValuesSupported:      []string{"ES256"},
 		RevocationEndpointAuthMethodsSupported:          []string{"private_key_jwt"},
 		RevocationEndpointAuthSigningAlgValuesSupported: []string{"ES256"},

--- a/corp104/oauth2/handler_test.go
+++ b/corp104/oauth2/handler_test.go
@@ -400,7 +400,7 @@ func TestHandlerWellKnown(t *testing.T) {
 		ScopesSupported:                   []string{"openid"},
 		ResponseTypes:                     []string{"id_token", "token"},
 		GrantTypesSupported:               []string{"implicit", "urn:ietf:params:oauth:grant-type:jwt-bearer"},
-		TokenEndpointAuthMethodsSupported: []string{"private_key_jwt"},
+		TokenEndpointAuthMethodsSupported: []string{"private_key_jwt", "private_key_jwt+session"},
 		TokenEndpointAuthSigningAlgValuesSupported:      []string{"ES256"},
 		RevocationEndpointAuthMethodsSupported:          []string{"private_key_jwt"},
 		RevocationEndpointAuthSigningAlgValuesSupported: []string{"ES256"},

--- a/corp104/sdk/go/corp104/swagger/o_auth2_client.go
+++ b/corp104/sdk/go/corp104/swagger/o_auth2_client.go
@@ -92,5 +92,5 @@ type OAuth2Client struct {
 }
 
 func (c OAuth2Client) IsPublic() bool {
-	return c.TokenEndpointAuthMethod == "none" || c.TokenEndpointAuthMethod == "session"
+	return c.TokenEndpointAuthMethod == "none" || c.TokenEndpointAuthMethod == "private_key_jwt+session"
 }


### PR DESCRIPTION
public client 的 `token_endpoint_auth_method` 由 `session` 調整為 `private_key_jwt+session`