### PR TITLE
調整 resource 以支援 GraphQL resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ plugin-*.so
 hydra-docker-bin
 cookies.txt
 vendor.orig
+.env

--- a/corp104/cmd/cli/handler_resource.go
+++ b/corp104/cmd/cli/handler_resource.go
@@ -84,6 +84,19 @@ func (h *ResourceHandler) CommitResource(cmd *cobra.Command, args []string) {
 	deleteCookies(cookieFileName)
 }
 
+func (h *ResourceHandler) DeleteResource(cmd *cobra.Command, args []string) {
+	m := h.newResourceManager(cmd)
+
+	if len(args) == 0 {
+		fmt.Print(cmd.UsageString())
+		return
+	}
+
+	response, err := m.DeleteOAuth2Resource(args[0])
+	checkResponse(response, err, http.StatusNoContent)
+	fmt.Println("OAuth2 resource deleted.")
+}
+
 func (h *ResourceHandler) GetResource(cmd *cobra.Command, args []string) {
 	m := h.newResourceManager(cmd)
 
@@ -92,11 +105,9 @@ func (h *ResourceHandler) GetResource(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	clientSecret, _ := cmd.Flags().GetString("urn")
-
-	cl, response, err := m.GetOAuth2Client(args[0], clientSecret)
+	resource, response, err := m.GetOAuth2Resource(args[0])
 	checkResponse(response, err, http.StatusOK)
-	fmt.Printf("%s\n", formatResponse(cl))
+	fmt.Printf("%s\n", formatResponse(resource))
 }
 
 func (h *ResourceHandler) getResourceFromPutCmd(cmd *cobra.Command) (hydra.OAuth2Resource, *hydra.JsonWebKey) {

--- a/corp104/cmd/clients_delete.go
+++ b/corp104/cmd/clients_delete.go
@@ -28,7 +28,7 @@ import (
 var clientsDeleteCmd = &cobra.Command{
 	Use:   "delete <id>",
 	Short: "Delete an OAuth 2.0 Client",
-	Long: `This command deletes a OAuth 2.0 Client by its ID.
+	Long: `This command deletes an OAuth 2.0 Client by its ID.
 
 Example:
   hydra clients delete client-1`,

--- a/corp104/cmd/resources_delete.go
+++ b/corp104/cmd/resources_delete.go
@@ -28,7 +28,7 @@ import (
 var resourcesDeleteCmd = &cobra.Command{
 	Use:   "delete <urn>",
 	Short: "Delete an OAuth 2.0 Resource",
-	Long: `This command deletes a OAuth 2.0 Resource by its URN.
+	Long: `This command deletes an OAuth 2.0 Resource by its URN.
 
 Example:
   hydra resources delete urn:104:v3:resource:rest:jobs`,

--- a/corp104/cmd/resources_delete.go
+++ b/corp104/cmd/resources_delete.go
@@ -24,17 +24,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// clientsDeleteCmd represents the delete command
-var clientsDeleteCmd = &cobra.Command{
-	Use:   "delete <id>",
-	Short: "Delete an OAuth 2.0 Client",
-	Long: `This command deletes a OAuth 2.0 Client by its ID.
+// resourcesDeleteCmd represents the delete command
+var resourcesDeleteCmd = &cobra.Command{
+	Use:   "delete <urn>",
+	Short: "Delete an OAuth 2.0 Resource",
+	Long: `This command deletes a OAuth 2.0 Resource by its URN.
 
 Example:
-  hydra clients delete client-1`,
-	Run: cmdHandler.Clients.DeleteClient,
+  hydra resources delete urn:104:v3:resource:rest:jobs`,
+	Run: cmdHandler.Resources.DeleteResource,
 }
 
 func init() {
-	clientsCmd.AddCommand(clientsDeleteCmd)
+	resourcesCmd.AddCommand(resourcesDeleteCmd)
 }

--- a/corp104/cmd/resources_get.go
+++ b/corp104/cmd/resources_get.go
@@ -5,12 +5,12 @@ import (
 )
 
 var resourcesGetCmd = &cobra.Command{
-	Use:   "get <id>",
+	Use:   "get <urn>",
 	Short: "Get an OAuth 2.0 Resource",
 	Long: `This command retrieves an OAuth 2.0 Resource by its URN.
 
 Example:
-  hydra resources get "urn:104v3:job:v1.0"`,
+  hydra resources get "urn:104:v3:resource:rest:jobs"`,
 	Run: cmdHandler.Resources.GetResource,
 }
 

--- a/corp104/cmd/resources_put.go
+++ b/corp104/cmd/resources_put.go
@@ -12,9 +12,19 @@ var resourcesPutCmd = &cobra.Command{
 
 Example:
   
+  # Restful
   hydra resources put \
      --endpoint "http://localhost:4444" \
-     --resource-metadata '{"uri":"https://v3ms.104.com.tw/resume","name":"resume","scope_auth_type":"company","grant_types":["urn:ietf:params:oauth:grant-type:jwt-bearer"],"scopes":[{"name":"resume:v1.0:semi-read","scope_auth_type":"","description":"讀半顯履歷資料"},{"name":"resume:v1.0:read","scope_auth_type":"","description":"讀履歷資料"}],"paths":[{"name":"/{resume_id}","methods":[{"name":"GET","description":"取得 resume 資料","scopes":["resume:v1.0:semi-read","resume:v1.0:read"]}]},{"name":"/","methods":[{"name":"GET","description":"取得 resume 列表","scopes":["resume:v1.0:semi-read","resume:v1.0:read"]}]}],"version":"1.0","contacts":["some.one@104.com.tw"],"description":"履歷資料API"}' \
+     --resource-metadata '{"uri":"https://v3ms.104.com.tw/jobs","name":"jobs","type":"rest","auth_service":"https://v3auth.104.com.tw","default_scope_auth_type":"company","grant_types":["urn:ietf:params:oauth:grant-type:jwt-bearer","client_credentials"],"scopes":[{"name":"rest:jobs:read","scope_auth_type":"","description":"關於rest:jobs:read"},{"name":"rest:jobs:write","scope_auth_type":"","description":"關於rest:jobs:write"}],"paths":[{"name":"/","methods":[{"name":"GET","description":"取得 job 列表","scopes":["rest:jobs:read","rest:jobs:write"]}]},{"name":"/","methods":[{"name":"POST","description":"取得 job 列表","scopes":["rest:jobs:write"]}]},{"name":"/{jobNo}","methods":[{"name":"GET","description":"取得 job 資料","scopes":["rest:jobs:read","rest:jobs:write"]}]},{"name":"/{jobNo}","methods":[{"name":"DELETE","description":"刪除 job 資料","scopes":["rest:jobs:write"]}]},{"name":"/{jobNo}","methods":[{"name":"PATCH","description":"修改 job 資料","scopes":["rest:jobs:write"]}]}],"contacts":["someone@104.com.tw"],"description":"公司資料"}' \
+     --signing-jwk '{"use":"sig","kty":"EC","kid":"private:89b940e8-a16f-48ce-a238-b52d7e252634","crv":"P-256","alg":"ES256","x":"6yi0V0cyxGVc5fEiu2U2PuZr4TxavTguccdcco1XyuA","y":"kX_biw0hYHyt1qaVP4EbP7WScIu9QyPK0Aj3fXpBRCg","d":"G4ExPHksANQZgLJzElHUGL43The7h0AKJE69qrgcZRo"}' \ 
+     --auth-public-jwk '{"use":"sig","kty":"EC","kid":"public:7d59b645-94e7-48c5-9f73-695b19294737","crv":"P-256","alg":"ES256","x":"zrt4vi0eIGY6iqAzpmrBqth33xl2D8R0kkp7laLqzYQ","y":"wbKUX4uBMidl840SANrfWPoTNU6YmYgYh-Aj51TrrWI"}' \ 
+     --user foo.bar \
+	 --pwd secret
+
+  # GraphQL
+  hydra resources put \
+     --endpoint "http://localhost:4444" \
+     --resource-metadata '{"uri":"https://v3ms.104.com.tw/graphql","name":"resumes","type":"graphql","auth_service":"https://v3auth.104.com.tw","default_scope_auth_type":"company","grant_types":["urn:ietf:params:oauth:grant-type:jwt-bearer"],"scopes":[{"name":"graphql:resumes:read","scope_auth_type":"","description":"關於rest:jobs:read"},{"name":"graphql:resumes:edu:read","scope_auth_type":"","description":"關於rest:jobs:edu:read"},{"name":"graphql:resumes:write","scope_auth_type":"","description":"關於rest:jobs:write"}],"graphql_operations":[{"name":"resumes","type":"query","scopes":["graphql:resumes:read","graphql:resumes:write"],"description":"查詢履歷"},{"name":"resumes/edu","type":"query","scopes":["graphql:resumes:edu:read","graphql:resumes:write"],"description":"查詢履歷的教育程度"},{"name":"createResume","type":"mutation","scopes":["graphql:resumes:write"],"description":"新增履歷"},{"name":"deleteResume","type":"mutation","scopes":["graphql:resumes:write"],"description":"刪除履歷"}],"contacts":["someone@104.com.tw"],"description":"歷履表"}' \
      --signing-jwk '{"use":"sig","kty":"EC","kid":"private:89b940e8-a16f-48ce-a238-b52d7e252634","crv":"P-256","alg":"ES256","x":"6yi0V0cyxGVc5fEiu2U2PuZr4TxavTguccdcco1XyuA","y":"kX_biw0hYHyt1qaVP4EbP7WScIu9QyPK0Aj3fXpBRCg","d":"G4ExPHksANQZgLJzElHUGL43The7h0AKJE69qrgcZRo"}' \ 
      --auth-public-jwk '{"use":"sig","kty":"EC","kid":"public:7d59b645-94e7-48c5-9f73-695b19294737","crv":"P-256","alg":"ES256","x":"zrt4vi0eIGY6iqAzpmrBqth33xl2D8R0kkp7laLqzYQ","y":"wbKUX4uBMidl840SANrfWPoTNU6YmYgYh-Aj51TrrWI"}' \ 
      --user foo.bar \

--- a/corp104/cmd/root_test.go
+++ b/corp104/cmd/root_test.go
@@ -122,6 +122,10 @@ func TestExecute(t *testing.T) {
 		//{args: []string{"help", "migrate", "sql"}},
 		{args: []string{"version"}},
 		{args: []string{"token", "flush", "--endpoint", backend}},
+		{args: []string{"resources", "put", "--endpoint", frontend, "--resource-metadata", `{"uri":"https://v3ms.104.com.tw/graphql","name":"resumes","type":"graphql","auth_service":"https://v3auth.104.com.tw","default_scope_auth_type":"company","grant_types":["urn:ietf:params:oauth:grant-type:jwt-bearer"],"scopes":[{"name":"graphql:resumes:read","scope_auth_type":"","description":"關於rest:jobs:read"},{"name":"graphql:resumes:edu:read","scope_auth_type":"","description":"關於rest:jobs:edu:read"},{"name":"graphql:resumes:write","scope_auth_type":"","description":"關於rest:jobs:write"}],"graphql_operations":[{"name":"resumes","type":"query","scopes":["graphql:resumes:read","graphql:resumes:write"],"description":"查詢履歷"},{"name":"resumes/edu","type":"query","scopes":["graphql:resumes:edu:read","graphql:resumes:write"],"description":"查詢履歷的教育程度"},{"name":"createResume","type":"mutation","scopes":["graphql:resumes:write"],"description":"新增履歷"},{"name":"deleteResume","type":"mutation","scopes":["graphql:resumes:write"],"description":"刪除履歷"}],"contacts":["someone@104.com.tw"],"description":"歷履表"}`, "--signing-jwk", `{"use":"sig","kty":"EC","kid":"private:89b940e8-a16f-48ce-a238-b52d7e252634","crv":"P-256","alg":"ES256","x":"6yi0V0cyxGVc5fEiu2U2PuZr4TxavTguccdcco1XyuA","y":"kX_biw0hYHyt1qaVP4EbP7WScIu9QyPK0Aj3fXpBRCg","d":"G4ExPHksANQZgLJzElHUGL43The7h0AKJE69qrgcZRo"}`, "--auth-public-jwk", "env:OFFLINE_PUBLIC_KEY", "--user", "foo.bar", "--pwd", "secret"}},
+		{args: []string{"resources", "commit", "--endpoint", frontend, "--urn", "urn:104:v3:resource:graphql:resumes", "--commit-code", "env:COMMIT_CODE"}},
+		{args: []string{"resources", "get", "--endpoint", frontend, "urn:104:v3:resource:graphql:resumes"}},
+		{args: []string{"resources", "delete", "--endpoint", backend, "urn:104:v3:resource:graphql:resumes"}},
 	} {
 		for i, v := range c.args {
 			envPrefix := "env:"

--- a/corp104/cmd/server/handler.go
+++ b/corp104/cmd/server/handler.go
@@ -288,7 +288,7 @@ func (h *Handler) RegisterRoutes(frontend, backend *httprouter.Router) {
 	h.Keys = newJWKHandler(c, frontend, backend, oauth2Provider, clientsManager)
 	h.Consent = newConsentHandler(c, frontend, backend, oauth2Provider, clientsManager)
 	h.OAuth2 = newOAuth2Handler(c, frontend, backend, ctx.ConsentManager, oauth2Provider, clientsManager, ctx.ResourceManager)
-	h.Resources = newResourceHandler(c, frontend, ctx.ResourceManager, oauth2Provider, clientsManager)
+	h.Resources = newResourceHandler(c, frontend, backend, ctx.ResourceManager, oauth2Provider, clientsManager)
 	_ = newHealthHandler(c, frontend)
 }
 

--- a/corp104/cmd/server/handler_resource_factory.go
+++ b/corp104/cmd/server/handler_resource_factory.go
@@ -39,7 +39,7 @@ func injectResourceManager(c *config.Config) {
 	ctx.ResourceManager = ctx.Connection.NewResourceManager()
 }
 
-func newResourceHandler(c *config.Config, router *httprouter.Router, manager resource.Manager, o fosite.OAuth2Provider, clm client.Manager) *resource.Handler {
+func newResourceHandler(c *config.Config, frontend, backend *httprouter.Router, manager resource.Manager, o fosite.OAuth2Provider, clm client.Manager) *resource.Handler {
 	w := herodot.NewJSONWriter(c.GetLogger())
 	w.ErrorEnhancer = writerErrorEnhancer
 
@@ -53,7 +53,7 @@ func newResourceHandler(c *config.Config, router *httprouter.Router, manager res
 	)
 
 	corsMiddleware := newCORSMiddleware(viper.GetString("CORS_ENABLED") == "true", c, corsx.ParseOptions(), o.IntrospectToken, clm.GetConcreteClient)
-	h.SetRoutes(router, corsMiddleware)
+	h.SetRoutes(frontend, backend, corsMiddleware)
 	return h
 }
 

--- a/corp104/resource/manager_0_sql_migrations_test.go
+++ b/corp104/resource/manager_0_sql_migrations_test.go
@@ -18,9 +18,9 @@ import (
 
 var createResourceMigrations = []*migrate.Migration{
 	{
-		Id: "urn:104:v3:resource:resume:v1.0",
+		Id: "urn:104:v3:resource:rest:jobs",
 		Up: []string{
-			`INSERT INTO hydra_resource (urn, content) VALUES ('urn:104:v3:resource:resume:v1.0', '{"urn":"urn:104:v3:resource:resume:v1.0","uri":"https://v3ms.104.com.tw/resume","name":"resume","scope_auth_type":"company","grant_types":["urn:ietf:params:oauth:grant-type:jwt-bearer"],"scopes":[{"name":"resume:v1.0:semi-read","scope_auth_type":"","description":"讀半顯履歷資料"},{"name":"resume:v1.0:read","scope_auth_type":"","description":"讀履歷資料"}],"paths":[{"name":"/{resume_id}","methods":[{"name":"GET","description":"取得 resume 資料","scopes":["resume:v1.0:semi-read","resume:v1.0:read"]}]},{"name":"/","methods":[{"name":"GET","description":"取得 resume 列表","scopes":["resume:v1.0:semi-read","resume:v1.0:read"]}]}],"version":"1.0","contacts":["some.one@104.com.tw"],"description":"履歷資料API"}')`,
+			`INSERT INTO hydra_resource (urn, content) VALUES ('urn:104:v3:resource:rest:jobs', '{"urn":"urn:104:v3:resource:rest:jobs","uri":"https://v3ms.104.com.tw/jobs","name":"jobs","type":"rest","auth_service":"https://v3auth.104.com.tw","default_scope":"rest:jobs","default_scope_auth_type":"company","grant_types":["urn:ietf:params:oauth:grant-type:jwt-bearer","client_credentials"],"scopes":[{"name":"rest:jobs:read","scope_auth_type":"","description":"關於rest:jobs:read"},{"name":"rest:jobs:write","scope_auth_type":"","description":"關於rest:jobs:write"}],"paths":[{"name":"/","methods":[{"name":"GET","description":"取得 job 列表","scopes":["rest:jobs:read","rest:jobs:write"]}]},{"name":"/","methods":[{"name":"POST","description":"取得 job 列表","scopes":["rest:jobs:write"]}]},{"name":"/{jobNo}","methods":[{"name":"GET","description":"取得 job 資料","scopes":["rest:jobs:read","rest:job:write"]}]},{"name":"/{jobNo}","methods":[{"name":"DELETE","description":"刪除 job 資料","scopes":["rest:jobs:write"]}]},{"name":"/{jobNo}","methods":[{"name":"PATCH","description":"修改 job 資料","scopes":["rest:jobs:write"]}]}],"contacts":["someone@104.com.tw"],"description":"公司資料"}')`,
 		},
 		Down: []string{
 			`DELETE FROM hydra_resource WHERE urn='1-data'`,
@@ -84,7 +84,7 @@ func TestMigrations(t *testing.T) {
 				})
 			}
 
-			for _, key := range []string{"urn:104:v3:resource:resume:v1.0"} {
+			for _, key := range []string{"urn:104:v3:resource:rest:jobs"} {
 				t.Run("resource="+key, func(t *testing.T) {
 					s := &resource.SQLManager{DB: db}
 					c, err := s.GetResource(context.TODO(), key)

--- a/corp104/resource/resource_test.go
+++ b/corp104/resource/resource_test.go
@@ -7,10 +7,11 @@ import (
 
 func TestResource(t *testing.T) {
 	r := &Resource{
-		Uri:     "https://v3ms.104.com.tw/job",
-		Name:    "job",
-		Version: "1.0",
+		Uri:  "https://v3ms.104.com.tw/jobs",
+		Name: "jobs",
+		Type: "rest",
 	}
 
-	assert.EqualValues(t, UrnPrefix+"job:v1.0", r.GetUrn())
+	assert.EqualValues(t, UrnPrefix+"rest:jobs", r.GetUrn())
+	assert.EqualValues(t, "rest:jobs", r.GetDefaultScope())
 }

--- a/corp104/resource/sdk_test.go
+++ b/corp104/resource/sdk_test.go
@@ -1,0 +1,316 @@
+package resource_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"github.com/goincremental/negroni-sessions"
+	"github.com/goincremental/negroni-sessions/cookiestore"
+	"github.com/julienschmidt/httprouter"
+	"github.com/ory/herodot"
+	"github.com/ory/hydra/corp104/jwk"
+	"github.com/ory/hydra/corp104/resource"
+	hydra "github.com/ory/hydra/corp104/sdk/go/corp104/swagger"
+	"github.com/ory/hydra/mock-dep"
+	"github.com/pborman/uuid"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/negroni"
+	"gopkg.in/square/go-jose.v2"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResourceSDK(t *testing.T) {
+	viper.Set("EMAIL_SERVICE_URL", "http://localhost:10025")
+	viper.Set("TEST_MODE", true)
+	webSessionName := "web_sid"
+	keyManager := &jwk.MemoryManager{Keys: map[string]*jose.JSONWebKeySet{}}
+	authSrvJwks, err := (&jwk.ECDSA256Generator{}).Generate(uuid.New(), "sig")
+	require.NoError(t, err)
+	require.NoError(t, keyManager.AddKeySet(context.TODO(), "jwk.offline", authSrvJwks))
+	ecAuthSrvPubJwk := authSrvJwks.Keys[1].Key.(*ecdsa.PublicKey)
+	authSrvPubJwk := &hydra.JsonWebKey{
+		Kid: authSrvJwks.Keys[1].KeyID,
+		Alg: authSrvJwks.Keys[1].Algorithm,
+		Crv: ecAuthSrvPubJwk.Params().Name,
+		Use: authSrvJwks.Keys[1].Use,
+		Kty: "EC",
+		X:   base64.RawURLEncoding.EncodeToString(ecAuthSrvPubJwk.X.Bytes()),
+		Y:   base64.RawURLEncoding.EncodeToString(ecAuthSrvPubJwk.Y.Bytes()),
+	}
+
+	// client key pair
+	cPrivKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	cPrivJwk := &hydra.JsonWebKey{
+		Alg: "ES256",
+		Crv: "P-256",
+		Use: "sig",
+		Kty: "EC",
+		X:   base64.RawURLEncoding.EncodeToString(cPrivKey.X.Bytes()),
+		Y:   base64.RawURLEncoding.EncodeToString(cPrivKey.Y.Bytes()),
+		D:   base64.RawURLEncoding.EncodeToString(cPrivKey.D.Bytes()),
+	}
+	cPubJwk := hydra.JsonWebKey{
+		Alg: "ES256",
+		Crv: "P-256",
+		Use: "sig",
+		Kty: "EC",
+		X:   base64.RawURLEncoding.EncodeToString(cPrivKey.X.Bytes()),
+		Y:   base64.RawURLEncoding.EncodeToString(cPrivKey.Y.Bytes()),
+	}
+
+	manager := resource.NewMemoryManager()
+	handler := resource.NewHandler(manager, herodot.NewJSONWriter(nil), keyManager, "http://localhost:4444", "jwk.offline")
+
+	router := httprouter.New()
+	handler.SetRoutes(router, router, func(h http.Handler) http.Handler {
+		return h
+	})
+	n := negroni.New()
+	store := cookiestore.New([]byte("secret"))
+	store.Options(sessions.Options{
+		Path:     "/",
+		MaxAge:   0,
+		Secure:   false,
+		HTTPOnly: true,
+	})
+	n.Use(sessions.Sessions(webSessionName, store))
+	n.UseHandler(router)
+	server := httptest.NewServer(n)
+	c := hydra.NewOAuth2ApiWithBasePath(server.URL)
+	handler.IssuerURL = server.URL
+
+	// start mock server
+	viper.Set("AD_LOGIN_URL", fmt.Sprintf("http://localhost:%d/ad/login", mock_dep.GetPort()))
+	err = mock_dep.StartMockServer()
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name	 string
+		resource hydra.OAuth2Resource
+	} {
+		{
+			name: "rest resource",
+			resource: createRestResource(cPubJwk),
+		},
+		{
+			name: "graphql resource",
+			resource: createGraphQLResource(cPubJwk),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			createResource := tc.resource
+
+			t.Run("case=create resource with invalid user credentials", func(t *testing.T) {
+				c.Configuration.Username = "foo.bar"
+				c.Configuration.Password = "wrong"
+
+				_, response, err := c.PutOAuth2Resource(createResource, cPrivJwk, authSrvPubJwk)
+				require.NoError(t, err)
+				require.EqualValues(t, http.StatusUnauthorized, response.StatusCode)
+			})
+
+			t.Run("case=create resource", func(t *testing.T) {
+				c.Configuration.Username = "foo.bar"
+				c.Configuration.Password = "secret"
+
+				// returned resource is correct on Create (session only)
+				result, response, err := c.PutOAuth2Resource(createResource, cPrivJwk, authSrvPubJwk)
+				require.NoError(t, err)
+				require.EqualValues(t, http.StatusAccepted, response.StatusCode, "%s", response.Payload)
+				assert.NotEmpty(t, result)
+				sessionCookie := getCookieFromResponse(response)
+				assert.NotEmpty(t, sessionCookie)
+
+				t.Run("case=commit resource", func(t *testing.T) {
+					commitResult, response, err := c.CommitOAuth2Resource(sessionCookie, viper.GetString("COMMIT_CODE"))
+					require.NoError(t, err)
+					require.EqualValues(t, http.StatusOK, response.StatusCode)
+					require.NotEmpty(t, commitResult.Location)
+
+					t.Run("case=get resource", func(t *testing.T) {
+						result, response, err := c.GetOAuth2Resource(createResource.GetUrn())
+						require.NoError(t, err)
+						require.EqualValues(t, http.StatusOK, response.StatusCode)
+						require.EqualValues(t, createResource.Uri, result.Uri)
+						require.EqualValues(t, createResource.Name, result.Name)
+						require.EqualValues(t, createResource.Type, result.Type)
+					})
+
+					// update resource
+					t.Run("case=update resource", func(t *testing.T) {
+						updateResource := createResource
+						updateResource.Scopes = append(updateResource.Scopes, )
+						updateResource.Description = updateResource.Description+"-updated"
+
+						_, response, err := c.PutOAuth2Resource(updateResource, cPrivJwk, authSrvPubJwk)
+						require.NoError(t, err)
+						require.EqualValues(t, http.StatusAccepted, response.StatusCode, "%s", response.Payload)
+
+						sessionCookie := getCookieFromResponse(response)
+						assert.NotEmpty(t, sessionCookie)
+
+						_, response, err = c.CommitOAuth2Resource(sessionCookie, viper.GetString("COMMIT_CODE"))
+						require.NoError(t, err)
+						require.EqualValues(t, http.StatusOK, response.StatusCode)
+
+						c, response, err := c.GetOAuth2Resource(updateResource.GetUrn())
+						require.NoError(t, err)
+						require.EqualValues(t, http.StatusOK, response.StatusCode)
+						require.EqualValues(t, updateResource.Scopes, c.Scopes)
+						require.EqualValues(t, updateResource.Description, c.Description)
+					})
+
+					t.Run("case=delete resource", func(t *testing.T) {
+						response, err := c.DeleteOAuth2Resource(createResource.GetUrn())
+						require.NoError(t, err)
+						require.EqualValues(t, http.StatusNoContent, response.StatusCode)
+					})
+				})
+			})
+		})
+	}
+
+	// stop mock server
+	mock_dep.StopMockServer()
+}
+
+func createRestResource(pubJwk hydra.JsonWebKey) hydra.OAuth2Resource {
+	return hydra.OAuth2Resource{
+		Urn:          "urn:104:v3:resource:rest:jobs",
+		Uri:          "https://v3ms.104.com.tw/jobs",
+		Name:         "jobs",
+		Type:         "rest",
+		AuthService:  "https://v3auth.104.com.tw",
+		DefaultScope: "rest:job",
+		DefaultScopeAuthType: "company",
+		GrantTypes:   []string{
+			"urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"client_credentials",
+		},
+		Scopes: []hydra.OAuth2ResourceScope{
+			{Name: "rest:jobs:read",  ScopeAuthType: "", Description: "關於rest:jobs:read"},
+			{Name: "rest:jobs:write", ScopeAuthType: "", Description: "關於rest:jobs:write"},
+		},
+		Paths: []hydra.OAuth2ResourcePath{
+			{
+				Name: "/",
+				Methods: []hydra.OAuth2ResourceMethod{
+					{
+						Name:        "GET",
+						Description: "取得 job 列表",
+						Scopes:      []string{"rest:jobs:read", "rest:jobs:write"},
+					},
+				},
+			},
+			{
+				Name: "/",
+				Methods: []hydra.OAuth2ResourceMethod{
+					{
+						Name:        "POST",
+						Description: "取得 job 列表",
+						Scopes:      []string{"rest:jobs:write"},
+					},
+				},
+			},
+			{
+				Name: "/{jobNo}",
+				Methods: []hydra.OAuth2ResourceMethod{
+					{
+						Name:        "GET",
+						Description: "取得 job 資料",
+						Scopes:      []string{"rest:jobs:read", "rest:jobs:write"},
+
+					},
+				},
+			},
+			{
+				Name: "/{jobNo}",
+				Methods: []hydra.OAuth2ResourceMethod{
+					{
+						Name:        "DELETE",
+						Description: "刪除 job 資料",
+						Scopes:      []string{"rest:jobs:write"},
+					},
+				},
+			},
+			{
+				Name: "/{jobNo}",
+				Methods: []hydra.OAuth2ResourceMethod{
+					{
+						Name:        "PATCH",
+						Description: "修改 job 資料",
+						Scopes:      []string{"rest:jobs:write"},
+					},
+				},
+			},
+		},
+		Contacts:      []string{"someone@104.com.tw"},
+		Description:   "公司資料",
+	}
+}
+
+func createGraphQLResource(pubJwk hydra.JsonWebKey) hydra.OAuth2Resource {
+	return hydra.OAuth2Resource{
+		Urn:          "urn:104:v3:resource:graphql:resumes",
+		Uri:          "https://v3ms.104.com.tw/graphql",
+		Name:         "resumes",
+		Type:         "graphql",
+		AuthService:  "https://v3auth.104.com.tw",
+		DefaultScope: "graphql:resumes",
+		DefaultScopeAuthType: "company",
+		GrantTypes:   []string{
+			"urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"client_credentials",
+		},
+		Scopes: []hydra.OAuth2ResourceScope{
+			{Name: "graphql:resumes:read", ScopeAuthType: "", Description: "關於rest:jobs:read"},
+			{Name: "graphql:resumes:edu:read", ScopeAuthType: "", Description: "關於rest:jobs:edu:read"},
+			{Name: "graphql:resumes:write", ScopeAuthType: "", Description: "關於rest:jobs:write"},
+		},
+		GraphQLOperations: []hydra.GraphQLOperation{
+			{
+				Name: "resumes",
+				Type: "query",
+				Scopes: []string{"graphql:resumes:read", "graphql:resumes:write"},
+				Description: "查詢履歷",
+			},
+			{
+				Name: "resumes/edu",
+				Type: "query",
+				Scopes: []string{"graphql:resumes:edu:read", "graphql:resumes:write"},
+				Description: "查詢履歷的教育程度",
+			},
+			{
+				Name: "createResume",
+				Type: "mutation",
+				Scopes: []string{"graphql:resumes:write"},
+				Description: "新增履歷",
+			},
+			{
+				Name: "deleteResume",
+				Type: "mutation",
+				Scopes: []string{"graphql:resumes:write"},
+				Description: "刪除履歷",
+			},
+		},
+		Contacts:      []string{"someone@104.com.tw"},
+		Description:   "歷履表",
+	}
+}
+
+func getCookieFromResponse(response *hydra.APIResponse) map[string]string {
+	respCookies := response.Cookies()
+	sessionCookie := map[string]string{}
+	for _, respCookie := range respCookies {
+		sessionCookie[respCookie.Name] = respCookie.Value
+	}
+	return sessionCookie
+}
+

--- a/corp104/resource/validator_test.go
+++ b/corp104/resource/validator_test.go
@@ -9,30 +9,39 @@ import (
 func TestValidate(t *testing.T) {
 	v := NewValidator()
 
-	for k, tc := range []struct {
+	for _, tc := range []struct {
+		name	  string
 		in        *Resource
 		check     func(t *testing.T, r *Resource)
 		expectErr bool
 		v         *Validator
 	}{
 		{
+			name: "valid rest resource",
 			in: &Resource{
-				Urn:         "urn:104:v3:job:v1.0",
-				Uri:         "https://v3ms.104.com.tw/job",
-				Name:        "job",
-				AuthService: "https://v3auth.104.com.tw",
+				Urn:          "urn:104:v3:resource:rest:jobs",
+				Uri:          "https://v3ms.104.com.tw/jobs",
+				Name:         "jobs",
+				Type:         "rest",
+				AuthService:  "https://v3auth.104.com.tw",
+				DefaultScope: "rest:job",
+				DefaultScopeAuthType: "company",
+				GrantTypes:   []string{
+					"urn:ietf:params:oauth:grant-type:jwt-bearer",
+					"client_credentials",
+				},
 				Scopes: []Scope{
-					{Name: "job:v1.0:read", AuthType: "user"},
-					{Name: "job:v1.0:list", AuthType: "user"},
+					{Name: "rest:jobs:read",  ScopeAuthType: "", Description: "關於rest:jobs:read"},
+					{Name: "rest:jobs:write", ScopeAuthType: "", Description: "關於rest:jobs:write"},
 				},
 				Paths: []Path{
 					{
-						Name: "/{jobNo}",
+						Name: "/",
 						Methods: []Method{
 							{
 								Name:        "GET",
-								Description: "Get job",
-								Scopes:      []string{"job:v1.0:read"},
+								Description: "取得 job 列表",
+								Scopes:      []string{"rest:jobs:read", "rest:jobs:write"},
 							},
 						},
 					},
@@ -40,30 +49,63 @@ func TestValidate(t *testing.T) {
 						Name: "/",
 						Methods: []Method{
 							{
+								Name:        "POST",
+								Description: "取得 job 列表",
+								Scopes:      []string{"rest:jobs:write"},
+							},
+						},
+					},
+					{
+						Name: "/{jobNo}",
+						Methods: []Method{
+							{
 								Name:        "GET",
-								Description: "Get job list",
-								Scopes:      []string{"job:v1.0:list"},
+								Description: "取得 job 資料",
+								Scopes:      []string{"rest:jobs:read", "rest:jobs:write"},
+
+							},
+						},
+					},
+					{
+						Name: "/{jobNo}",
+						Methods: []Method{
+							{
+								Name:        "DELETE",
+								Description: "刪除 job 資料",
+								Scopes:      []string{"rest:jobs:write"},
+							},
+						},
+					},
+					{
+						Name: "/{jobNo}",
+						Methods: []Method{
+							{
+								Name:        "PATCH",
+								Description: "修改 job 資料",
+								Scopes:      []string{"rest:jobs:write"},
 							},
 						},
 					},
 				},
-				GrantTypes:    []string{"urn:ietf:params:oauth:grant-type:jwt-bearer"},
-				Version:       "1.0",
 				Contacts:      []string{"someone@104.com.tw"},
-				ScopeAuthType: "client",
-				Description:   "Job data",
+				Description:   "公司資料",
 			},
 			check: func(t *testing.T, r *Resource) {},
 		},
 		{
+			name: "invalid scheme of Uri",
 			in: &Resource{
-				Urn:         "urn:104:v3:job:v1.0",
-				Uri:         "https://v3ms.104.com.tw/job",
-				Name:        "job",
+				Urn:         "urn:104:v3:resource:rest:jobs",
+				Uri:         "http://v3ms.104.com.tw/jobs",
+				Name:        "jobs",
+				Type:        "rest",
 				AuthService: "https://v3auth.104.com.tw",
+				DefaultScope: "rest:jobs",
+				DefaultScopeAuthType: "company",
+				GrantTypes:    []string{"urn:ietf:params:oauth:grant-type:jwt-bearer"},
 				Scopes: []Scope{
-					{Name: "job:v1.0:read", AuthType: "user"},
-					{Name: "job:v1.0:list", AuthType: "user"},
+					{Name: "rest:jobs:read", ScopeAuthType: "user"},
+					{Name: "rest:jobs:list", ScopeAuthType: "user"},
 				},
 				Paths: []Path{
 					{
@@ -87,24 +129,26 @@ func TestValidate(t *testing.T) {
 						},
 					},
 				},
-				GrantTypes:    []string{"urn:ietf:params:oauth:grant-type:jwt-bearer"},
-				Version:       "1.0",
 				Contacts:      []string{"someone@104.com.tw"},
-				ScopeAuthType: "wrong",
 				Description:   "Job data",
 			},
 			check:     func(t *testing.T, r *Resource) {},
 			expectErr: true,
 		},
 		{
+			name: "uri must not contain a fragment",
 			in: &Resource{
-				Urn:         "urn:104:v3:job:v1.0",
-				Uri:         "https://v3ms.104.com.tw/job",
-				Name:        "job",
+				Urn:         "urn:104:v3:resource:rest:jobs",
+				Uri:         "https://v3ms.104.com.tw/jobs#fragment",
+				Name:        "jobs",
+				Type:        "rest",
 				AuthService: "https://v3auth.104.com.tw",
+				DefaultScope: "rest:jobs",
+				DefaultScopeAuthType: "company",
+				GrantTypes:    []string{"urn:ietf:params:oauth:grant-type:jwt-bearer"},
 				Scopes: []Scope{
-					{Name: "job:v1.0:read", AuthType: "wrong"},
-					{Name: "job:v1.0:list", AuthType: "user"},
+					{Name: "rest:jobs:read", ScopeAuthType: "user"},
+					{Name: "rest:jobs:list", ScopeAuthType: "user"},
 				},
 				Paths: []Path{
 					{
@@ -128,21 +172,27 @@ func TestValidate(t *testing.T) {
 						},
 					},
 				},
-				GrantTypes:    []string{"urn:ietf:params:oauth:grant-type:jwt-bearer"},
-				Version:       "1.0",
 				Contacts:      []string{"someone@104.com.tw"},
-				ScopeAuthType: "company",
 				Description:   "Job data",
 			},
 			check:     func(t *testing.T, r *Resource) {},
 			expectErr: true,
 		},
 		{
+			name: "invalid default scope auth type",
 			in: &Resource{
-				Urn:         "urn:104:v3:job:v1.0",
-				Uri:         "https://v3ms.104.com.tw/job",
-				Name:        "job",
+				Urn:         "urn:104:v3:rest:jobs",
+				Uri:         "https://v3ms.104.com.tw/jobs",
+				Name:        "jobs",
+				Type:        "rest",
 				AuthService: "https://v3auth.104.com.tw",
+				DefaultScope: "rest:jobs",
+				DefaultScopeAuthType: "wrong",
+				GrantTypes:    []string{"urn:ietf:params:oauth:grant-type:jwt-bearer"},
+				Scopes: []Scope{
+					{Name: "rest:jobs:read", ScopeAuthType: "user"},
+					{Name: "rest:jobs:list", ScopeAuthType: "user"},
+				},
 				Paths: []Path{
 					{
 						Name: "/{jobNo}",
@@ -150,7 +200,7 @@ func TestValidate(t *testing.T) {
 							{
 								Name:        "GET",
 								Description: "Get job",
-								Scopes:      []string{"job:v1.0:read"},
+								Scopes:      []string{"rest:jobs:read"},
 							},
 						},
 					},
@@ -160,131 +210,449 @@ func TestValidate(t *testing.T) {
 							{
 								Name:        "GET",
 								Description: "Get job list",
-								Scopes:      []string{"job:v1.0:list"},
+								Scopes:      []string{"rest:jobs:list"},
 							},
 						},
 					},
 				},
-				GrantTypes:    []string{"urn:ietf:params:oauth:grant-type:jwt-bearer"},
-				Version:       "1.0",
 				Contacts:      []string{"someone@104.com.tw"},
-				ScopeAuthType: "user",
 				Description:   "Job data",
 			},
 			check:     func(t *testing.T, r *Resource) {},
 			expectErr: true,
 		},
 		{
+			name: "invalid grant types",
 			in: &Resource{
-				Urn:         "urn:104:v3:job:v1.0",
-				Uri:         "http://v3ms.104.com.tw/job",
-				Name:        "job",
+				Urn:         "urn:104:v3:rest:jobs",
+				Uri:         "https://v3ms.104.com.tw/jobs",
+				Name:        "jobs",
+				Type:        "rest",
 				AuthService: "https://v3auth.104.com.tw",
-				Version:     "1.0",
-			},
-			check:     func(t *testing.T, r *Resource) {},
-			expectErr: true,
-		},
-		{
-			in: &Resource{
-				Urn:         "urn:104:v3:job:v1.0",
-				Uri:         "https://v3ms.104.com.tw/job#ha",
-				Name:        "job",
-				AuthService: "https://v3auth.104.com.tw",
-				Version:     "1.0",
-			},
-			check:     func(t *testing.T, r *Resource) {},
-			expectErr: true,
-		},
-		{
-			in: &Resource{
-				Urn:           "urn:104:v3:job:v1.0",
-				Uri:           "https://v3ms.104.com.tw/job",
-				Name:          "job",
-				AuthService:   "https://v3auth.104.com.tw",
-				Version:       "1.0",
-				ScopeAuthType: "none",
+				DefaultScope: "rest:jobs",
+				DefaultScopeAuthType: "company",
 				GrantTypes:    []string{"wrong"},
-			},
-			check:     func(t *testing.T, r *Resource) {},
-			expectErr: true,
-		},
-		{
-			in: &Resource{
-				Urn:           "urn:104:v3:job:v1.0",
-				Uri:           "https://v3ms.104.com.tw/job",
-				Name:          "job",
-				AuthService:   "https://v3auth.104.com.tw",
-				Version:       "1.0",
-				ScopeAuthType: "none",
-				GrantTypes:    []string{"urn:ietf:params:oauth:grant-type:jwt-bearer", "wrong"},
-			},
-			check:     func(t *testing.T, r *Resource) {},
-			expectErr: true,
-		},
-		{
-			in: &Resource{
-				Urn:         "urn:104:v3:job:v1.0",
-				Uri:         "https://v3ms.104.com.tw/job",
-				Name:        "job",
-				AuthService: "https://v3auth.104.com.tw",
-			},
-			check:     func(t *testing.T, r *Resource) {},
-			expectErr: true,
-		},
-		{
-			in: &Resource{
-				Urn:         "urn:104:v3:job:v1.0",
-				Uri:         "https://v3ms.104.com.tw/job",
-				Name:        "_job",
-				AuthService: "https://v3auth.104.com.tw",
-			},
-			check:     func(t *testing.T, r *Resource) {},
-			expectErr: true,
-		},
-		{
-			in: &Resource{
-				Urn:         "urn:104:v3:job:v1.0",
-				Uri:         "https://v3ms.104.com.tw/job",
-				Name:        "job",
-				AuthService: "https://v3auth.104.com.tw",
-				Version:     "v1",
-			},
-			check:     func(t *testing.T, r *Resource) {},
-			expectErr: true,
-		},
-		{
-			in: &Resource{
-				Urn:         "urn:104:v3:job:v1.0",
-				Uri:         "https://v3ms.104.com.tw/job",
-				Name:        "job",
-				AuthService: "https://v3auth.104.com.tw",
-				Version:     "1.0",
 				Scopes: []Scope{
-					{Name: "resume:v1.0:read", AuthType: "user"},
-					{Name: "resume:v1.0:list", AuthType: "user"},
+					{Name: "rest:jobs:read", ScopeAuthType: "user"},
+					{Name: "rest:jobs:list", ScopeAuthType: "user"},
+				},
+				Paths: []Path{
+					{
+						Name: "/{jobNo}",
+						Methods: []Method{
+							{
+								Name:        "GET",
+								Description: "Get job",
+								Scopes:      []string{"rest:jobs:read"},
+							},
+						},
+					},
+					{
+						Name: "/",
+						Methods: []Method{
+							{
+								Name:        "GET",
+								Description: "Get job list",
+								Scopes:      []string{"rest:jobs:list"},
+							},
+						},
+					},
+				},
+				Contacts:      []string{"someone@104.com.tw"},
+				Description:   "Job data",
+			},
+			check:     func(t *testing.T, r *Resource) {},
+			expectErr: true,
+		},
+		{
+			name: "paths not defined",
+			in: &Resource{
+				Urn:         "urn:104:v3:rest:jobs",
+				Uri:         "https://v3ms.104.com.tw/jobs",
+				Name:        "jobs",
+				Type:        "rest",
+				AuthService: "https://v3auth.104.com.tw",
+				DefaultScope: "rest:jobs",
+				DefaultScopeAuthType: "company",
+				GrantTypes:    []string{"client_credentials"},
+				Scopes: []Scope{
+					{Name: "jobs:v1.0:read", ScopeAuthType: ""},
+					{Name: "jobs:v1.0:list", ScopeAuthType: ""},
 				},
 			},
 			check:     func(t *testing.T, r *Resource) {},
 			expectErr: true,
 		},
 		{
+			name: "paths must not be empty",
 			in: &Resource{
-				Urn:         "urn:104:v3:job:v1.0",
-				Uri:         "https://v3ms.104.com.tw/job",
-				Name:        "job",
+				Urn:         "urn:104:v3:rest:jobs",
+				Uri:         "https://v3ms.104.com.tw/jobs",
+				Name:        "jobs",
+				Type:        "rest",
 				AuthService: "https://v3auth.104.com.tw",
-				Version:     "1.0",
+				DefaultScope: "rest:jobs",
+				DefaultScopeAuthType: "company",
+				GrantTypes:    []string{"client_credentials"},
 				Scopes: []Scope{
-					{Name: "resume:v1.0:read", AuthType: "user"},
-					{Name: "resume:v1.0:read", AuthType: "user"},
+					{Name: "jobs:v1.0:read", ScopeAuthType: ""},
+					{Name: "jobs:v1.0:list", ScopeAuthType: ""},
 				},
+				Paths: []Path{},
+				Contacts:      []string{"someone@104.com.tw"},
+				Description:   "Job data",
 			},
 			check:     func(t *testing.T, r *Resource) {},
+			expectErr: true,
+		},
+		{
+			name: "path name not defined",
+			in: &Resource{
+				Urn:          "urn:104:v3:resource:rest:jobs",
+				Uri:          "https://v3ms.104.com.tw/jobs",
+				Name:         "jobs",
+				Type:         "rest",
+				AuthService:  "https://v3auth.104.com.tw",
+				DefaultScope: "rest:job",
+				DefaultScopeAuthType: "company",
+				GrantTypes:   []string{
+					"urn:ietf:params:oauth:grant-type:jwt-bearer",
+					"client_credentials",
+				},
+				Scopes: []Scope{
+					{Name: "rest:jobs:read",  ScopeAuthType: "", Description: "關於rest:jobs:read"},
+					{Name: "rest:jobs:write", ScopeAuthType: "", Description: "關於rest:jobs:write"},
+				},
+				Paths: []Path{
+					{
+						Methods: []Method{
+							{
+								Name:        "GET",
+								Description: "取得 job 列表",
+								Scopes:      []string{"rest:jobs:read", "rest:jobs:write"},
+							},
+						},
+					},
+					{
+						Methods: []Method{
+							{
+								Name:        "GET",
+								Description: "取得 job 列表",
+								Scopes:      []string{"rest:jobs:write"},
+							},
+						},
+					},
+				},
+				Contacts:      []string{"someone@104.com.tw"},
+				Description:   "公司資料",
+			},
+			check:     func(t *testing.T, r *Resource) {},
+			expectErr: true,
+		},
+		{
+			name: "methods must not be empty",
+			in: &Resource{
+				Urn:          "urn:104:v3:resource:rest:jobs",
+				Uri:          "https://v3ms.104.com.tw/jobs",
+				Name:         "jobs",
+				Type:         "rest",
+				AuthService:  "https://v3auth.104.com.tw",
+				DefaultScope: "rest:job",
+				DefaultScopeAuthType: "company",
+				GrantTypes:   []string{
+					"urn:ietf:params:oauth:grant-type:jwt-bearer",
+					"client_credentials",
+				},
+				Scopes: []Scope{
+					{Name: "rest:jobs:read",  ScopeAuthType: "", Description: "關於rest:jobs:read"},
+					{Name: "rest:jobs:write", ScopeAuthType: "", Description: "關於rest:jobs:write"},
+				},
+				Paths: []Path{
+					{
+						Name: "/",
+						Methods: []Method{},
+					},
+				},
+				Contacts:      []string{"someone@104.com.tw"},
+				Description:   "公司資料",
+			},
+			check:     func(t *testing.T, r *Resource) {},
+			expectErr: true,
+		},
+		{
+			name: "invalid path name",
+			in: &Resource{
+				Urn:          "urn:104:v3:resource:rest:jobs",
+				Uri:          "https://v3ms.104.com.tw/jobs",
+				Name:         "jobs",
+				Type:         "rest",
+				AuthService:  "https://v3auth.104.com.tw",
+				DefaultScope: "rest:job",
+				DefaultScopeAuthType: "company",
+				GrantTypes:   []string{
+					"urn:ietf:params:oauth:grant-type:jwt-bearer",
+					"client_credentials",
+				},
+				Scopes: []Scope{
+					{Name: "rest:jobs:read",  ScopeAuthType: "", Description: "關於rest:jobs:read"},
+					{Name: "rest:jobs:write", ScopeAuthType: "", Description: "關於rest:jobs:write"},
+				},
+				Paths: []Path{
+					{
+						Name: "jobs",
+						Methods: []Method{
+							{
+								Name:        "GET",
+								Description: "取得 job 列表",
+								Scopes:      []string{"rest:jobs:read", "rest:jobs:write"},
+							},
+						},
+					},
+					{
+						Name: "jobs",
+						Methods: []Method{
+							{
+								Name:        "POST",
+								Description: "取得 job 列表",
+								Scopes:      []string{"rest:jobs:write"},
+							},
+						},
+					},
+				},
+				Contacts:      []string{"someone@104.com.tw"},
+				Description:   "公司資料",
+			},
+			check:     func(t *testing.T, r *Resource) {},
+			expectErr: true,
+		},
+		{
+			name: "invalid method name",
+			in: &Resource{
+				Urn:          "urn:104:v3:resource:rest:jobs",
+				Uri:          "https://v3ms.104.com.tw/jobs",
+				Name:         "jobs",
+				Type:         "rest",
+				AuthService:  "https://v3auth.104.com.tw",
+				DefaultScope: "rest:job",
+				DefaultScopeAuthType: "company",
+				GrantTypes:   []string{
+					"urn:ietf:params:oauth:grant-type:jwt-bearer",
+					"client_credentials",
+				},
+				Scopes: []Scope{
+					{Name: "rest:jobs:read",  ScopeAuthType: "", Description: "關於rest:jobs:read"},
+					{Name: "rest:jobs:write", ScopeAuthType: "", Description: "關於rest:jobs:write"},
+				},
+				Paths: []Path{
+					{
+						Name: "/",
+						Methods: []Method{
+							{
+								Name:        "Wrong",
+								Description: "取得 job 列表",
+								Scopes:      []string{"rest:jobs:read", "rest:jobs:write"},
+							},
+						},
+					},
+					{
+						Name: "/",
+						Methods: []Method{
+							{
+								Name:        "post",
+								Description: "取得 job 列表",
+								Scopes:      []string{"rest:jobs:write"},
+							},
+						},
+					},
+				},
+				Contacts:      []string{"someone@104.com.tw"},
+				Description:   "公司資料",
+			},
+			check:     func(t *testing.T, r *Resource) {},
+			expectErr: true,
+		},
+		{
+			name: "method has duplicate scope",
+			in: &Resource{
+				Urn:          "urn:104:v3:resource:rest:jobs",
+				Uri:          "https://v3ms.104.com.tw/jobs",
+				Name:         "jobs",
+				Type:         "rest",
+				AuthService:  "https://v3auth.104.com.tw",
+				DefaultScope: "rest:job",
+				DefaultScopeAuthType: "company",
+				GrantTypes:   []string{
+					"urn:ietf:params:oauth:grant-type:jwt-bearer",
+					"client_credentials",
+				},
+				Scopes: []Scope{
+					{Name: "rest:jobs:read",  ScopeAuthType: "", Description: "關於rest:jobs:read"},
+					{Name: "rest:jobs:write", ScopeAuthType: "", Description: "關於rest:jobs:write"},
+				},
+				Paths: []Path{
+					{
+						Name: "/",
+						Methods: []Method{
+							{
+								Name:        "GET",
+								Description: "取得 job 列表",
+								Scopes:      []string{"rest:jobs:read", "rest:jobs:read"},
+							},
+						},
+					},
+				},
+				Contacts:      []string{"someone@104.com.tw"},
+				Description:   "公司資料",
+			},
+			check:     func(t *testing.T, r *Resource) {},
+			expectErr: true,
+		},
+		{
+			name: "method scope is not defined in the resource scope list",
+			in: &Resource{
+				Urn:         "urn:104:v3:rest:jobs",
+				Uri:         "https://v3ms.104.com.tw/jobs",
+				Name:        "jobs",
+				Type:        "rest",
+				AuthService: "https://v3auth.104.com.tw",
+				DefaultScope: "rest:jobs",
+				DefaultScopeAuthType: "company",
+				GrantTypes:    []string{"client_credentials"},
+				Scopes: []Scope{
+					{Name: "rest:jobs:read", ScopeAuthType: "user"},
+					{Name: "rest:jobs:list", ScopeAuthType: "user"},
+				},
+				Paths: []Path{
+					{
+						Name: "/{jobNo}",
+						Methods: []Method{
+							{
+								Name:        "GET",
+								Description: "Get job",
+								Scopes:      []string{"rest:jobs:write"},
+							},
+						},
+					},
+					{
+						Name: "/",
+						Methods: []Method{
+							{
+								Name:        "GET",
+								Description: "Get job list",
+								Scopes:      []string{"rest:jobs:list"},
+							},
+						},
+					},
+				},
+				Contacts:      []string{"someone@104.com.tw"},
+				Description:   "Job data",
+			},
+			check:     func(t *testing.T, r *Resource) {},
+			expectErr: true,
+		},
+		{
+			name: "valid graphql resource",
+			in: &Resource{
+				Urn:          "urn:104:v3:resource:graphql:resumes",
+				Uri:          "https://v3ms.104.com.tw/graphql",
+				Name:         "resumes",
+				Type:         "graphql",
+				AuthService:  "https://v3auth.104.com.tw",
+				DefaultScope: "graphql:resumes",
+				DefaultScopeAuthType: "company",
+				GrantTypes:   []string{
+					"urn:ietf:params:oauth:grant-type:jwt-bearer",
+					"client_credentials",
+				},
+				Scopes: []Scope{
+					{Name: "graphql:resumes:read", ScopeAuthType: "", Description: "關於rest:jobs:read"},
+					{Name: "graphql:resumes:edu:read", ScopeAuthType: "", Description: "關於rest:jobs:edu:read"},
+					{Name: "graphql:resumes:write", ScopeAuthType: "", Description: "關於rest:jobs:write"},
+				},
+				GraphQLOperations: []GraphQLOperation{
+					{
+						Name: "resumes",
+						Type: "query",
+						Scopes: []string{"graphql:resumes:read", "graphql:resumes:write"},
+						Description: "查詢履歷",
+					},
+					{
+						Name: "resumes/edu",
+						Type: "query",
+						Scopes: []string{"graphql:resumes:edu:read", "graphql:resumes:write"},
+						Description: "查詢履歷的教育程度",
+					},
+					{
+						Name: "createResume",
+						Type: "mutation",
+						Scopes: []string{"graphql:resumes:write"},
+						Description: "新增履歷",
+					},
+					{
+						Name: "deleteResume",
+						Type: "mutation",
+						Scopes: []string{"graphql:resumes:write"},
+						Description: "刪除履歷",
+					},
+				},
+				Contacts:      []string{"someone@104.com.tw"},
+				Description:   "歷履表",
+			},
+			check: func(t *testing.T, r *Resource) {},
+		},
+		{
+			name: "graphql_operations not defined",
+			in: &Resource{
+				Urn:          "urn:104:v3:resource:graphql:resumes",
+				Uri:          "https://v3ms.104.com.tw/graphql",
+				Name:         "resumes",
+				Type:         "graphql",
+				AuthService:  "https://v3auth.104.com.tw",
+				DefaultScope: "graphql:resumes",
+				DefaultScopeAuthType: "company",
+				GrantTypes:   []string{
+					"urn:ietf:params:oauth:grant-type:jwt-bearer",
+					"client_credentials",
+				},
+				Scopes: []Scope{
+					{Name: "graphql:resumes:read", ScopeAuthType: "", Description: "關於rest:jobs:read"},
+					{Name: "graphql:resumes:edu:read", ScopeAuthType: "", Description: "關於rest:jobs:edu:read"},
+					{Name: "graphql:resumes:write", ScopeAuthType: "", Description: "關於rest:jobs:write"},
+				},
+				Contacts:      []string{"someone@104.com.tw"},
+				Description:   "歷履表",
+			},
+			check: func(t *testing.T, r *Resource) {},
+			expectErr: true,
+		},
+		{
+			name: "graphql_operations must not be empty",
+			in: &Resource{
+				Urn:          "urn:104:v3:resource:graphql:resumes",
+				Uri:          "https://v3ms.104.com.tw/graphql",
+				Name:         "resumes",
+				Type:         "graphql",
+				AuthService:  "https://v3auth.104.com.tw",
+				DefaultScope: "graphql:resumes",
+				DefaultScopeAuthType: "company",
+				GrantTypes:   []string{
+					"urn:ietf:params:oauth:grant-type:jwt-bearer",
+					"client_credentials",
+				},
+				Scopes: []Scope{
+					{Name: "graphql:resumes:read", ScopeAuthType: "", Description: "關於rest:jobs:read"},
+					{Name: "graphql:resumes:edu:read", ScopeAuthType: "", Description: "關於rest:jobs:edu:read"},
+					{Name: "graphql:resumes:write", ScopeAuthType: "", Description: "關於rest:jobs:write"},
+				},
+				GraphQLOperations: []GraphQLOperation{},
+				Contacts:      []string{"someone@104.com.tw"},
+				Description:   "歷履表",
+			},
+			check: func(t *testing.T, r *Resource) {},
 			expectErr: true,
 		},
 	} {
-		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
+		t.Run(fmt.Sprintf("case=%s", tc.name), func(t *testing.T) {
 			if tc.v == nil {
 				tc.v = v
 			}

--- a/corp104/sdk/go/corp104/sdk_api.go
+++ b/corp104/sdk/go/corp104/sdk_api.go
@@ -65,6 +65,7 @@ type OAuth2API interface {
 
 	PutOAuth2Resource(body swagger.OAuth2Resource, signingJwk *swagger.JsonWebKey, authSrvPubJwk *swagger.JsonWebKey) (*swagger.PutResourceResponse, *swagger.APIResponse, error)
 	CommitOAuth2Resource(cookies map[string]string, commitCode string) (*swagger.CommitResourceResponse, *swagger.APIResponse, error)
+	DeleteOAuth2Resource(urn string) (*swagger.APIResponse, error)
 	GetOAuth2Resource(urn string) (*swagger.OAuth2Resource, *swagger.APIResponse, error)
 	ListOAuth2Resources(authSrvPubJwk *swagger.JsonWebKey, limit int64, offset int64) ([]swagger.OAuth2Resource, *swagger.APIResponse, error)
 }

--- a/corp104/sdk/go/corp104/swagger/docs/OAuth2Api.md
+++ b/corp104/sdk/go/corp104/swagger/docs/OAuth2Api.md
@@ -29,6 +29,7 @@ Method | HTTP request | Description
 [**Userinfo**](OAuth2Api.md#Userinfo) | **Post** /userinfo | OpenID Connect Userinfo
 [**WellKnown**](OAuth2Api.md#WellKnown) | **Get** /jwks.json | Get Well-Known JSON Web Keys
 [**CommitOAuth2Resource**](OAuth2Api.md#CommitOAuth2Resource) | **Put** /resources/commit | Commit an OAuth 2.0 Resource 
+[**DeleteOAuth2Resource**](OAuth2Api.md#DeleteOAuth2Resource) | **Delete** /resources/{urn} | Deletes an OAuth 2.0 Resource
 [**GetOAuth2Resource**](OAuth2Api.md#GetOAuth2Resource) | **Get** /resources/{urn} | Get an OAuth 2.0 Resource
 [**ListOAuth2Resources**](OAuth2Api.md#ListOAuth2Resources) | **Get** /resources | List OAuth 2.0 Resources
 [**PutOAuth2Resource**](OAuth2Api.md#PutOAuth2Resource) | **Put** /resources | Create or update an OAuth 2.0 Resource
@@ -259,7 +260,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-Require client credentials
+Client credentials is required
 
 ### HTTP request headers
 
@@ -458,7 +459,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+AD user credentials required
 
 ### HTTP request headers
 
@@ -749,6 +750,35 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
+# **DeleteOAuth2Resource**
+> DeleteOAuth2Resource($urn)
+
+Deletes an OAuth 2.0 Resource
+
+Delete an existing OAuth 2.0 Resource by its URN.
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **urn** | **string**| The urn of the OAuth 2.0 Resource. | 
+ 
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
 # **GetOAuth2Resource**
 > OAuth2Resource GetOAuth2Resource($urn)
 
@@ -765,11 +795,11 @@ Name | Type | Description  | Notes
  
 ### Return type
 
-[**OAuth2Resource**](oAuth2Resource.md)
+[**OAuth2Resource**](OAuth2Resource.md)
 
 ### Authorization
 
-Require client credentials
+No authorization required
 
 ### HTTP request headers
 
@@ -796,7 +826,7 @@ Name | Type | Description  | Notes
  
 ### Return type
 
-[**[]OAuth2Resource**](oAuth2Resource.md)
+[**[]OAuth2Resource**](OAuth2Resource.md)
 
 ### Authorization
 
@@ -818,7 +848,7 @@ Create or update an OAuth 2.0 resource.
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | [**OAuth2Client**](OAuth2Client.md)|  |
+ **body** | [**OAuth2Resource**](OAuth2Resource.md)|  |
  **signingJwk** | [**JsonWebKey**](JsonWebKey.md)| JWK for signing resource statement |
  **authSrvPubJwk** | [**JsonWebKey**](JsonWebKey.md)| Auth Service's public JWK | 
 
@@ -828,7 +858,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+AD user credentials required
 
 ### HTTP request headers
 

--- a/corp104/sdk/go/corp104/swagger/docs/OAuth2Resource.md
+++ b/corp104/sdk/go/corp104/swagger/docs/OAuth2Resource.md
@@ -1,0 +1,65 @@
+# OAuth2Resource
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**Urn** | **string** | Unique name of the resource. | [default to null]
+**Uri** | **string** | Base URI of the resource.    | [default to null]
+**Name** | **string** | Name of the resource. | [default to null]
+**Type** | **string** | Type of the resource. | [default to null]
+**AuthService** | **string** | AuthService is the URI of the authorization server responsible for the resource. | [optional] [default to null]
+**Paths** | [**[]OAuth2ResourcePath**](#oauth2resourcepath) | List of paths provided by the resource. | Required when type is `rest`. [default to null]
+**GraphQLOperations** | [**[]GraphQLOperation**](#graphqloperation) | List of GraphQL operations provided by the resource. | Required when type is `graphql`. [default to null]
+**Scopes** | [**[]OAuth2ResourceScope**](#oauth2resourcescope) | List of scopes supported by the resource. | [default to null]
+**GrantTypes** | **[]string** | List of grant types that allow access to the resource. | [default to null]
+**Contacts** | **[]string** | List of contacts responsible for the resource. | [default to null]
+**DefaultScope** | **string** | Default scope of the resource. | [default to null]
+**DefaultScopeAuthType** | **string** | Auth type of the default scope. | [default to null]
+**Description** | **string** | Description of the resource. | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+# OAuth2ResourcePath
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**Name** | **string** | URI path of the resource. | [default to null]
+**Methods** | [**[]OAuth2ResourceMethod**](#oauth2resourcemethod) | List of HTTP methods supported by the resource. | [default to null]
+**Description** | **string** | Description of the Path. | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+# OAuth2ResourceScope
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**Name** | **string** | HTTP method name. | [default to null]
+**ScopeAuthType** | **string** | Auth type of the scope. | [default to null]
+**Description** | **string** | Description of the scope. | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+# OAuth2ResourceMethod
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**Name** | **string** | HTTP method name. | [default to null]
+**Scopes** | **[]string** | Scopes supported by the method. | [default to null]
+**Description** | **string** | Description of the method. | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+# GraphQLOperation
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**Name** | **string** |Name of the GraphQL operation. | [default to null]
+**Type** | **string** | Type of the GraphQL operation. | [default to null]
+**Scopes** | **[]string** | Scopes supported by the GraphQL operation. | [default to null]
+**Description** | **string** | Description of the GraphQL operation. | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/corp104/sdk/go/corp104/swagger/o_auth2_api.go
+++ b/corp104/sdk/go/corp104/swagger/o_auth2_api.go
@@ -513,7 +513,7 @@ func (a OAuth2Api) GetLoginRequest(challenge string) (*LoginRequest, *APIRespons
  */
 func (a OAuth2Api) GetOAuth2Client(id, secret string) (*OAuth2Client, *APIResponse, error) {
 	if id == "" || secret == "" {
-		return nil, nil, errors.New("require client credentials")
+		return nil, nil, errors.New("client credentials is required")
 	}
 
 	var localVarHttpMethod = strings.ToUpper("Get")
@@ -1939,6 +1939,68 @@ func (a OAuth2Api) CommitOAuth2Resource(cookies map[string]string, commitCode st
 }
 
 /**
+ * Deletes an OAuth 2.0 Resource
+ * Delete an existing OAuth 2.0 Resource by its URN.
+ *
+ * @param urn The URN of the OAuth 2.0 Resource.
+ * @return void
+ */
+func (a OAuth2Api) DeleteOAuth2Resource(urn string) (*APIResponse, error) {
+	if urn == "" {
+		return nil, errors.New("resource urn is required")
+	}
+
+	var localVarHttpMethod = strings.ToUpper("Delete")
+	// create path and map variables
+	localVarPath := a.Configuration.BasePath + "/resources/{urn}"
+	localVarPath = strings.Replace(localVarPath, "{urn}", fmt.Sprintf("%v", urn), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := make(map[string]string)
+	var localVarPostBody interface{}
+	var localVarFileName string
+	var localVarFileBytes []byte
+	// add default headers if any
+	for key := range a.Configuration.DefaultHeader {
+		localVarHeaderParams[key] = a.Configuration.DefaultHeader[key]
+	}
+
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHttpContentType := a.Configuration.APIClient.SelectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{
+		"application/json",
+	}
+
+	// set Accept header
+	localVarHttpHeaderAccept := a.Configuration.APIClient.SelectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+	localVarHttpResponse, err := a.Configuration.APIClient.CallAPI(localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+
+	var localVarURL, _ = url.Parse(localVarPath)
+	localVarURL.RawQuery = localVarQueryParams.Encode()
+	var localVarAPIResponse = &APIResponse{Operation: "DeleteOAuth2Resource", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	if localVarHttpResponse != nil {
+		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
+		localVarAPIResponse.Payload = localVarHttpResponse.Body()
+	}
+
+	if err != nil {
+		return localVarAPIResponse, err
+	}
+	return localVarAPIResponse, err
+}
+
+/**
  * Get an OAuth 2.0 resource.
  * Get an OAUth 2.0 resource by its URN.
  *
@@ -1947,7 +2009,7 @@ func (a OAuth2Api) CommitOAuth2Resource(cookies map[string]string, commitCode st
  */
 func (a OAuth2Api) GetOAuth2Resource(urn string) (*OAuth2Resource, *APIResponse, error) {
 	if urn == "" {
-		return nil, nil, errors.New("require resource URN")
+		return nil, nil, errors.New("resource urn is required")
 	}
 
 	var localVarHttpMethod = http.MethodGet

--- a/corp104/sdk/go/corp104/swagger/o_auth2_resource.go
+++ b/corp104/sdk/go/corp104/swagger/o_auth2_resource.go
@@ -1,9 +1,15 @@
 package swagger
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
-	ResourceUrnPrefix = "urn:104v3:resource:"
+	UrnPrefix = "urn:104:v3:resource:"
+
+	RestResourceType = "rest"
+	GraphQLResourceType = "graphql"
 )
 
 // Resource represents an OAuth 2.0 Resource.
@@ -19,72 +25,87 @@ type OAuth2Resource struct {
 	// Name of the resource.
 	Name string `json:"name" validate:"required"`
 
+	// Type of the resource.
+	Type string `json:"type" validate:"required,oneof=rest graphql"`
+
 	// AuthService is the URI of the authorization server responsible for the resource
 	AuthService string `json:"auth_server,omitempty"`
 
 	// List of paths provided by the resource
-	Paths []Path `json:"paths" validate:"required,min=1"`
+	Paths []OAuth2ResourcePath `json:"paths,omitempty" validate:"dive"`
+
+	// List of GraphQL operations provided by the resource
+	GraphQLOperations []GraphQLOperation `json:"graphql_operations,omitempty" validate:"dive"`
 
 	// List of scopes supported by the resource
-	Scopes []Scope `json:"scopes,omitempty"`
+	Scopes []OAuth2ResourceScope `json:"scopes,omitempty" validate:"dive"`
 
 	// List of grant types that allow access to the resource
-	GrantTypes []string `json:"grant_types" validate:"required,min=1,max=1"`
-
-	// Resource version, in the format major_number.minor_number
-	Version string `json:"version" validate:"required"`
+	GrantTypes []string `json:"grant_types" validate:"required,min=1,dive,oneof=client_credentials implicit urn:ietf:params:oauth:grant-type:jwt-bearer"`
 
 	// List of contacts responsible for the resource
 	Contacts []string `json:"contacts" validate:"required,min=1"`
 
-	// Auth type of the scope in the resource level
-	ScopeAuthType string `json:"scope_auth_type" validate:"required,oneof=none client user company"`
+	// Default scope of the resource
+	DefaultScope string `json:"default_scope"`
+
+	// Auth type of the default scope
+	DefaultScopeAuthType string `json:"default_scope_auth_type" validate:"required,oneof=none client user company"`
 
 	// Description of the resource
 	Description string `json:"description" validate:"required"`
 }
 
 func (r *OAuth2Resource) GetUrn() string {
-	return fmt.Sprintf("%s%s:v%s", ResourceUrnPrefix, r.Name, r.Version)
+	return fmt.Sprintf("%s%s:%s", UrnPrefix, r.Type, r.Name)
 }
 
-// Resource represents an OAuth 2.0 Resource Path.
-//
-// swagger:model path
-type Path struct {
+func (r *OAuth2Resource) GetDefaultScope() string {
+	return strings.TrimPrefix(r.GetUrn(), UrnPrefix)
+}
+
+type OAuth2ResourcePath struct {
 	// URI path of the resource.
-	Name string `json:"name"`
+	Name string `json:"name" validate:"required"`
 
 	// List of HTTP methods supported by the resource.
-	Methods []Method `json:"methods"`
+	Methods []OAuth2ResourceMethod `json:"methods" validate:"required,min=1,dive"`
 
 	// Description of the Path
 	Description string `json:"description,omitempty"`
 }
 
-// Resource represents an OAuth 2.0 Resource Path Method.
-//
-// swagger:model method
-type Method struct {
+type OAuth2ResourceMethod struct {
 	// HTTP method name.
-	Name string `json:"name"`
+	Name string `json:"name" validate:"required,oneof=CONNECT DELETE GET HEAD PATCH POST PUT OPTIONS TRACE"`
 
-	// Scopes supported by the Path
-	Scopes []string `json:"scopes,omitempty"`
+	// Scopes supported by the method
+	Scopes []string `json:"scopes"`
 
 	// Description of the method
 	Description string `json:"description,omitempty"`
 }
 
-// Resource represents an OAuth 2.0 Resource Scope.
-//
-// swagger:model scope
-type Scope struct {
+type OAuth2ResourceScope struct {
 	// Name of the scope.
-	Name string `json:"name"`
+	Name string `json:"name" validate:"required`
 
 	// Auth type of the scope
-	AuthType string `json:"scope_auth_type,omitempty"`
+	ScopeAuthType string `json:"scope_auth_type"`
+
+	// Description of the scope
+	Description string `json:"description,omitempty"`
+}
+
+type GraphQLOperation struct {
+	// Name of the scope.
+	Name string `json:"name" validate:"required`
+
+	// Type of the GraphQL operation.
+	Type string `json:"type" validate:"required,oneof=query mutation subscription"`
+
+	// Scopes supported by the GraphQL operation
+	Scopes []string `json:"scopes"`
 
 	// Description of the scope
 	Description string `json:"description,omitempty"`


### PR DESCRIPTION
## Auth Server
1. 調整 resource，主要修改為加入 `Type` 及 `GraphQLOperations` ，取消 `Version`
2. 調整 validation rule，加入 GraphQL resource 的驗證
3. Admin router 增加 `DELETE /resources/{urn}` route
4. 增加 test cases

## SDK
1. 因應 resource metadata payload 調整，修改相關 api
2. 調整 swagger docs
3. 增加 test cases

## CLI
1. 調整 `--resource-metadata` 參數內容
2. 增加  `hydra resources delete <urn>` cmd
3. 增加 test cases