### PR TITLE
調整 client.GetScopes() 將 resource URN 轉換成 resource scopes

### DIFF
--- a/corp104/client/manager_wrapper.go
+++ b/corp104/client/manager_wrapper.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"context"
+	"strings"
+
+	"github.com/ory/fosite"
+	"github.com/ory/hydra/corp104/resource"
+)
+
+type ManagerWrapper struct {
+	Manager
+	ResourceManager resource.Manager
+}
+
+func (m *ManagerWrapper) GetClient(ctx context.Context, id string) (fosite.Client, error) {
+	c, err := m.GetConcreteClient(ctx, id)
+	if err != nil {
+		return c, err
+	}
+	// Scope 中包含 resource 定義
+	if strings.Contains(c.Scope, resource.UrnPrefix) {
+		// 取得 resource scopes
+		rsmap, err := m.ResourceManager.GetResourceScopeMap()
+		if err != nil {
+			return c, err
+		}
+		// 將 resource urn 轉換為對應的 scopes
+		for _, scope := range c.GetScopes() {
+			if strings.HasPrefix(scope, resource.UrnPrefix) {
+				c.Scope = strings.Replace(c.Scope, scope, strings.Join(rsmap[scope], " "), 1)
+			}
+		}
+	}
+	return c, nil
+}

--- a/corp104/client/manager_wrapper_test.go
+++ b/corp104/client/manager_wrapper_test.go
@@ -1,0 +1,193 @@
+package client_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"github.com/ory/fosite"
+	"github.com/ory/hydra/corp104/client"
+	"github.com/ory/hydra/corp104/resource"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/square/go-jose.v2"
+	"strings"
+	"testing"
+)
+
+func TestManagerWrapper_GetClient(t *testing.T) {
+	ctx := context.TODO()
+	resourceManager, err := initTestResourceManager(ctx)
+	assert.NoError(t, err)
+
+	m := &client.ManagerWrapper{
+		Manager: client.NewMemoryManager(&fosite.BCrypt{}),
+		ResourceManager: resourceManager,
+	}
+
+	var ecTestKey256, _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	c := &client.Client{
+		ClientID: uuid.New(),
+		JSONWebKeys: &jose.JSONWebKeySet{
+			Keys: []jose.JSONWebKey{
+				{
+					Key:       &ecTestKey256.PublicKey,
+					KeyID:     "public:" + uuid.New(),
+					Algorithm: "ES256",
+					Use:       "sig",
+				},
+			},
+		},
+		TokenEndpointAuthMethod: "private_key_jwt",
+		GrantTypes:              []string{"client_credentials"},
+		Name:                    "foo",
+		ClientURI:               "https://localhost/client",
+		Contacts:                []string{"周星馳(星輝海外有限公司)"},
+		SoftwareId:              "4d51529c-37cd-424c-ba19-cba742d60903",
+		SoftwareVersion:         "0.0.1",
+		Scope:                   "graphql:resumes:read graphql:resumes:write urn:104:v3:resource:rest:jobs",
+	}
+	err = m.CreateClient(ctx, c)
+	assert.NoError(t, err)
+
+	fc, err := m.GetClient(ctx, c.ClientID)
+	assert.NoError(t, err)
+	// fc.GetScopes() 的傳回值會將 "urn:104:v3:resource:rest:jobs" 轉換為 "rest:jobs rest:jobs:read rest:jobs:write"
+	assert.Equal(t, "graphql:resumes:read graphql:resumes:write rest:jobs rest:jobs:read rest:jobs:write", strings.Join(fc.GetScopes(), " "))
+}
+
+func initTestResourceManager(ctx context.Context) (resource.Manager, error) {
+	rm := resource.NewMemoryManager()
+
+	// create "jobs" resource
+	jobs := &resource.Resource{
+		Urn:          "urn:104:v3:resource:rest:jobs",
+		Uri:          "https://v3ms.104.com.tw/jobs",
+		Name:         "jobs",
+		Type:         "rest",
+		AuthService:  "https://v3auth.104.com.tw",
+		DefaultScope: "rest:jobs",
+		DefaultScopeAuthType: "company",
+		GrantTypes:   []string{
+			"urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"client_credentials",
+		},
+		Scopes: []resource.Scope{
+			{Name: "rest:jobs:read",  ScopeAuthType: "", Description: "關於rest:jobs:read"},
+			{Name: "rest:jobs:write", ScopeAuthType: "", Description: "關於rest:jobs:write"},
+		},
+		Paths: []resource.Path{
+			{
+				Name: "/",
+				Methods: []resource.Method{
+					{
+						Name:        "GET",
+						Description: "取得 job 列表",
+						Scopes:      []string{"rest:jobs:read", "rest:jobs:write"},
+					},
+				},
+			},
+			{
+				Name: "/",
+				Methods: []resource.Method{
+					{
+						Name:        "POST",
+						Description: "取得 job 列表",
+						Scopes:      []string{"rest:jobs:write"},
+					},
+				},
+			},
+			{
+				Name: "/{jobNo}",
+				Methods: []resource.Method{
+					{
+						Name:        "GET",
+						Description: "取得 job 資料",
+						Scopes:      []string{"rest:jobs:read", "rest:jobs:write"},
+
+					},
+				},
+			},
+			{
+				Name: "/{jobNo}",
+				Methods: []resource.Method{
+					{
+						Name:        "DELETE",
+						Description: "刪除 job 資料",
+						Scopes:      []string{"rest:jobs:write"},
+					},
+				},
+			},
+			{
+				Name: "/{jobNo}",
+				Methods: []resource.Method{
+					{
+						Name:        "PATCH",
+						Description: "修改 job 資料",
+						Scopes:      []string{"rest:jobs:write"},
+					},
+				},
+			},
+		},
+		Contacts:      []string{"someone@104.com.tw"},
+		Description:   "公司資料",
+	}
+	err := rm.CreateResource(ctx, jobs)
+	if err != nil {
+		return nil, err
+	}
+
+	// create "resumes" resource
+	resumes := &resource.Resource{
+		Urn:          "urn:104:v3:resource:graphql:resumes",
+		Uri:          "https://v3ms.104.com.tw/graphql",
+		Name:         "resumes",
+		Type:         "graphql",
+		AuthService:  "https://v3auth.104.com.tw",
+		DefaultScope: "graphql:resumes",
+		DefaultScopeAuthType: "company",
+		GrantTypes:   []string{
+			"urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"client_credentials",
+		},
+		Scopes: []resource.Scope{
+			{Name: "graphql:resumes:read", ScopeAuthType: "", Description: "關於rest:jobs:read"},
+			{Name: "graphql:resumes:edu:read", ScopeAuthType: "", Description: "關於rest:jobs:edu:read"},
+			{Name: "graphql:resumes:write", ScopeAuthType: "", Description: "關於rest:jobs:write"},
+		},
+		GraphQLOperations: []resource.GraphQLOperation{
+			{
+				Name: "resumes",
+				Type: "query",
+				Scopes: []string{"graphql:resumes:read", "graphql:resumes:write"},
+				Description: "查詢履歷",
+			},
+			{
+				Name: "resumes/edu",
+				Type: "query",
+				Scopes: []string{"graphql:resumes:edu:read", "graphql:resumes:write"},
+				Description: "查詢履歷的教育程度",
+			},
+			{
+				Name: "createResume",
+				Type: "mutation",
+				Scopes: []string{"graphql:resumes:write"},
+				Description: "新增履歷",
+			},
+			{
+				Name: "deleteResume",
+				Type: "mutation",
+				Scopes: []string{"graphql:resumes:write"},
+				Description: "刪除履歷",
+			},
+		},
+		Contacts:      []string{"someone@104.com.tw"},
+		Description:   "歷履表",
+	}
+	err = rm.CreateResource(ctx, resumes)
+	if err != nil {
+		return nil, err
+	}
+
+	return rm, nil
+}

--- a/corp104/client/sdk_test.go
+++ b/corp104/client/sdk_test.go
@@ -114,7 +114,7 @@ func TestClientSDK(t *testing.T) {
 	resourceManager := &resource.MemoryManager{}
 
 	manager := client.NewMemoryManager(nil)
-	handler := client.NewHandler(manager, herodot.NewJSONWriter(nil), []string{}, []string{"public"}, keyManager, resourceManager,"http://localhost:4444", "jwk.offline")
+	handler := client.NewHandler(manager, herodot.NewJSONWriter(nil), []string{}, []string{"public"}, keyManager, resourceManager, "http://localhost:4444", "jwk.offline")
 
 	router := httprouter.New()
 	handler.SetRoutes(router, router, func(h http.Handler) http.Handler {
@@ -157,7 +157,6 @@ func TestClientSDK(t *testing.T) {
 			c.Configuration.Password = "wrong"
 
 			_, response, err := c.PutOAuth2Client(createClient, cPrivJwk, authSrvPubJwk)
-			fmt.Println(err)
 			require.NoError(t, err)
 			require.EqualValues(t, http.StatusUnauthorized, response.StatusCode)
 		})

--- a/corp104/client/sdk_test.go
+++ b/corp104/client/sdk_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ory/herodot"
 	"github.com/ory/hydra/corp104/client"
 	"github.com/ory/hydra/corp104/jwk"
+	"github.com/ory/hydra/corp104/resource"
 	hydra "github.com/ory/hydra/corp104/sdk/go/corp104/swagger"
 	"github.com/ory/hydra/mock-dep"
 	"github.com/ory/hydra/pkg"
@@ -110,8 +111,10 @@ func TestClientSDK(t *testing.T) {
 		Y:   base64.RawURLEncoding.EncodeToString(cPrivKey.Y.Bytes()),
 	}
 
+	resourceManager := &resource.MemoryManager{}
+
 	manager := client.NewMemoryManager(nil)
-	handler := client.NewHandler(manager, herodot.NewJSONWriter(nil), []string{"foo", "bar"}, []string{"public"}, keyManager, "http://localhost:4444", "jwk.offline")
+	handler := client.NewHandler(manager, herodot.NewJSONWriter(nil), []string{}, []string{"public"}, keyManager, resourceManager,"http://localhost:4444", "jwk.offline")
 
 	router := httprouter.New()
 	handler.SetRoutes(router, router, func(h http.Handler) http.Handler {
@@ -154,6 +157,7 @@ func TestClientSDK(t *testing.T) {
 			c.Configuration.Password = "wrong"
 
 			_, response, err := c.PutOAuth2Client(createClient, cPrivJwk, authSrvPubJwk)
+			fmt.Println(err)
 			require.NoError(t, err)
 			require.EqualValues(t, http.StatusUnauthorized, response.StatusCode)
 		})

--- a/corp104/cmd/server/handler.go
+++ b/corp104/cmd/server/handler.go
@@ -272,23 +272,22 @@ func (h *Handler) RegisterRoutes(frontend, backend *httprouter.Router) {
 
 	// Set up dependencies
 	injectJWKManager(c)
-	clientsManager := newClientManager(c)
+	resourceManager := newResourceManager(c)
+	clientsManager := &client.ManagerWrapper{Manager: newClientManager(c), ResourceManager: resourceManager}
 
 	injectFositeStore(c, clientsManager)
 	injectConsentManager(c, clientsManager)
 
 	oauth2Provider := newOAuth2Provider(c)
 
-	injectResourceManager(c)
-
 	h.initOfflineJWK()
 
 	// Set up handlers
-	h.Clients = newClientHandler(c, frontend, backend, clientsManager, oauth2Provider)
+	h.Clients = newClientHandler(c, frontend, backend, clientsManager, oauth2Provider, resourceManager)
 	h.Keys = newJWKHandler(c, frontend, backend, oauth2Provider, clientsManager)
 	h.Consent = newConsentHandler(c, frontend, backend, oauth2Provider, clientsManager)
-	h.OAuth2 = newOAuth2Handler(c, frontend, backend, ctx.ConsentManager, oauth2Provider, clientsManager, ctx.ResourceManager)
-	h.Resources = newResourceHandler(c, frontend, backend, ctx.ResourceManager, oauth2Provider, clientsManager)
+	h.OAuth2 = newOAuth2Handler(c, frontend, backend, ctx.ConsentManager, oauth2Provider, clientsManager, resourceManager)
+	h.Resources = newResourceHandler(c, frontend, backend, resourceManager, oauth2Provider, clientsManager)
 	_ = newHealthHandler(c, frontend)
 }
 

--- a/corp104/cmd/server/handler_client_factory.go
+++ b/corp104/cmd/server/handler_client_factory.go
@@ -23,6 +23,7 @@ package server
 import (
 	"github.com/ory/fosite"
 	"github.com/ory/go-convenience/corsx"
+	"github.com/ory/hydra/corp104/resource"
 	"github.com/spf13/viper"
 	"strings"
 
@@ -37,7 +38,7 @@ func newClientManager(c *config.Config) client.Manager {
 	return ctx.Connection.NewClientManager(ctx.Hasher)
 }
 
-func newClientHandler(c *config.Config, frontend, backend *httprouter.Router, manager client.Manager, o fosite.OAuth2Provider) *client.Handler {
+func newClientHandler(c *config.Config, frontend, backend *httprouter.Router, manager client.Manager, o fosite.OAuth2Provider, rm resource.Manager) *client.Handler {
 	w := herodot.NewJSONWriter(c.GetLogger())
 	w.ErrorEnhancer = writerErrorEnhancer
 
@@ -48,6 +49,7 @@ func newClientHandler(c *config.Config, frontend, backend *httprouter.Router, ma
 		strings.Split(c.DefaultClientScope, ","),
 		c.GetSubjectTypesSupported(),
 		c.Context().KeyManager,
+		rm,
 		c.Issuer,
 		c.GetOfflineJWKSName(),
 	)

--- a/corp104/cmd/server/handler_resource_factory.go
+++ b/corp104/cmd/server/handler_resource_factory.go
@@ -34,9 +34,9 @@ import (
 	"github.com/ory/hydra/pkg"
 )
 
-func injectResourceManager(c *config.Config) {
+func newResourceManager(c *config.Config) resource.Manager {
 	ctx := c.Context()
-	ctx.ResourceManager = ctx.Connection.NewResourceManager()
+	return ctx.Connection.NewResourceManager()
 }
 
 func newResourceHandler(c *config.Config, frontend, backend *httprouter.Router, manager resource.Manager, o fosite.OAuth2Provider, clm client.Manager) *resource.Handler {

--- a/corp104/config/context.go
+++ b/corp104/config/context.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ory/fosite/handler/oauth2"
 	"github.com/ory/hydra/corp104/consent"
 	"github.com/ory/hydra/corp104/jwk"
-	"github.com/ory/hydra/corp104/resource"
 	"github.com/ory/hydra/pkg"
 )
 
@@ -38,5 +37,4 @@ type Context struct {
 	KeyManager      jwk.Manager
 	ConsentManager  consent.Manager
 	WebSession      *WebSession
-	ResourceManager resource.Manager
 }

--- a/corp104/oauth2/handler.go
+++ b/corp104/oauth2/handler.go
@@ -246,7 +246,6 @@ func (h *Handler) WellKnownHandler(w http.ResponseWriter, r *http.Request) {
 		scopesSupported = append(scopesSupported, strings.Split(h.ScopesSupported, ",")...)
 	}
 	resourceScopes, _ := h.ResourceManager.GetAllScopeNames()
-	fmt.Println("resourceScopes: ", resourceScopes)
 	scopesSupported = append(scopesSupported, resourceScopes...)
 
 	claims := (&WellKnown{

--- a/corp104/resource/manager.go
+++ b/corp104/resource/manager.go
@@ -36,4 +36,6 @@ type Manager interface {
 	GetResources(ctx context.Context, limit, offset int) (map[string]Resource, error)
 
 	GetAllScopeNames() ([]string, error)
+
+	GetResourceScopeMap() (map[string][]string, error)
 }

--- a/corp104/resource/manager_memory.go
+++ b/corp104/resource/manager_memory.go
@@ -100,10 +100,30 @@ func (m *MemoryManager) GetAllScopeNames() ([]string, error) {
 
 	var scopes []string
 	for _, resource := range m.Resources {
+		scopes = append(scopes, resource.GetUrn())
+		scopes = append(scopes, resource.GetDefaultScope())
 		for _, scope := range resource.Scopes {
 			scopes = append(scopes, scope.Name)
 		}
 	}
 
 	return scopes, nil
+}
+
+func (m *MemoryManager) GetResourceScopeMap() (map[string][]string, error) {
+	m.RLock()
+	defer m.RUnlock()
+
+	rsmap := make(map[string][]string)
+	for _, resource := range m.Resources {
+		var scopes []string
+		// resource 的 scopes，包含 default scope 及 scopes 宣告
+		scopes = append(scopes, resource.GetDefaultScope())
+		for _, scope := range resource.Scopes {
+			scopes = append(scopes, scope.Name)
+		}
+		rsmap[resource.GetUrn()] = scopes
+	}
+
+	return rsmap, nil
 }

--- a/corp104/resource/manager_sql.go
+++ b/corp104/resource/manager_sql.go
@@ -182,9 +182,33 @@ func (m *SQLManager) GetAllScopeNames() ([]string, error) {
 	}
 	var scopes []string
 	for _, resource := range resources {
+		scopes = append(scopes, resource.GetUrn())
+		scopes = append(scopes, resource.GetDefaultScope())
 		for _, scope := range resource.Scopes {
 			scopes = append(scopes, scope.Name)
 		}
 	}
 	return scopes, nil
+}
+
+func (m *SQLManager) GetResourceScopeMap() (map[string][]string, error) {
+	d := make([]sqlData, 0)
+	resources := make(map[string]Resource)
+
+	if err := m.DB.Select(&d, "SELECT * FROM hydra_resource ORDER BY urn"); err != nil {
+		return nil, sqlcon.HandleError(err)
+	}
+
+	rsmap := make(map[string][]string)
+	for _, resource := range resources {
+		// resource 的 scopes，包含 default scope 及 scopes 宣告
+		var scopes []string
+		scopes = append(scopes, resource.GetDefaultScope())
+		for _, scope := range resource.Scopes {
+			scopes = append(scopes, scope.Name)
+		}
+		rsmap[resource.GetUrn()] = scopes
+	}
+
+	return rsmap, nil
 }

--- a/corp104/resource/sdk_test.go
+++ b/corp104/resource/sdk_test.go
@@ -188,7 +188,7 @@ func createRestResource(pubJwk hydra.JsonWebKey) hydra.OAuth2Resource {
 		Name:         "jobs",
 		Type:         "rest",
 		AuthService:  "https://v3auth.104.com.tw",
-		DefaultScope: "rest:job",
+		DefaultScope: "rest:jobs",
 		DefaultScopeAuthType: "company",
 		GrantTypes:   []string{
 			"urn:ietf:params:oauth:grant-type:jwt-bearer",

--- a/corp104/resource/validator_test.go
+++ b/corp104/resource/validator_test.go
@@ -24,7 +24,7 @@ func TestValidate(t *testing.T) {
 				Name:         "jobs",
 				Type:         "rest",
 				AuthService:  "https://v3auth.104.com.tw",
-				DefaultScope: "rest:job",
+				DefaultScope: "rest:jobs",
 				DefaultScopeAuthType: "company",
 				GrantTypes:   []string{
 					"urn:ietf:params:oauth:grant-type:jwt-bearer",

--- a/corp104/sdk/go/corp104/swagger/docs/OAuth2Api.md
+++ b/corp104/sdk/go/corp104/swagger/docs/OAuth2Api.md
@@ -260,7 +260,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-Client credentials is required
+Client credentials required
 
 ### HTTP request headers
 

--- a/corp104/sdk/go/corp104/swagger/o_auth2_api.go
+++ b/corp104/sdk/go/corp104/swagger/o_auth2_api.go
@@ -513,7 +513,7 @@ func (a OAuth2Api) GetLoginRequest(challenge string) (*LoginRequest, *APIRespons
  */
 func (a OAuth2Api) GetOAuth2Client(id, secret string) (*OAuth2Client, *APIResponse, error) {
 	if id == "" || secret == "" {
-		return nil, nil, errors.New("client credentials is required")
+		return nil, nil, errors.New("client credentials required")
 	}
 
 	var localVarHttpMethod = strings.ToUpper("Get")


### PR DESCRIPTION
## 調整項目
### client
1. Client  註冊時，增加 scope validation，必須是 `/resource` 清單中的 resource urn、default_scope 或 `scopes`.name
2. 新增 client.ManagerWrapper，override `GetClient()` 將 scope 中的 resource urn 轉換成 resource scopes

### server
1. 將 newResourceManager() 移動到 newClientManager() 之前
2. client.Manager 改用 client.ManagerWrapper
3. 將 ResourceManager 從 Context struct 中移除，改為 newXXXHandler() 時注入

### resource
1. resource.Manager 增加 GetResourceScopeMap()