### PR TITLE
Feature/access token claims and header modify

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,14 +3,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:cca3327b3dee8a054db710d8c7866e0bceb2fb97b97ba053931e097c6ed1c6a0"
+  digest = "1:0882725154be71b89dd9c848ced067913aa5b182dcf8ca56b8dab6efb029b030"
   name = "github.com/104corp/vip3-go-auth"
   packages = [
     "vip3auth",
     "vip3auth/jwt",
   ]
   pruneopts = ""
-  revision = "cd4db6a70e10241f22a68f5670c47efe76e64830"
+  revision = "31ea07a13dd06f2457e5d1e16f827f8096f335b2"
 
 [[projects]]
   branch = "master"
@@ -256,6 +256,14 @@
   packages = ["proto"]
   pruneopts = ""
   revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
+
+[[projects]]
+  digest = "1:a25a2c5ae694b01713fb6cd03c3b1ac1ccc1902b9f0a922680a88ec254f968e1"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = ""
+  revision = "9b3b1e0f5f99ae461456d768e7d301a7acdaa2d8"
+  version = "v1.1.0"
 
 [[projects]]
   digest = "1:20ed7daa9b3b38b6d1d39b48ab3fd31122be5419461470d0c28de3e121c93ecf"
@@ -641,12 +649,12 @@
   version = "v2.1.0"
 
 [[projects]]
-  digest = "1:63e142fc50307bcb3c57494913cfc9c12f6061160bdf97a678f78c71615f939b"
+  digest = "1:a5484d4fa43127138ae6e7b2299a6a52ae006c7f803d98d717f60abf3e97192e"
   name = "github.com/pborman/uuid"
   packages = ["."]
   pruneopts = ""
-  revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
-  version = "v1.1"
+  revision = "adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1"
+  version = "v1.2"
 
 [[projects]]
   digest = "1:9c740db1f7015dffa093aa5c70862d277fe49f5e92b56ca5d0d69ef0e37c01db"

--- a/corp104/cmd/server/handler_oauth2_factory.go
+++ b/corp104/cmd/server/handler_oauth2_factory.go
@@ -145,7 +145,8 @@ func newOAuth2Provider(c *config.Config) fosite.OAuth2Provider {
 		compose.OAuth2TokenRevocationFactory,
 		compose.OAuth2TokenIntrospectionFactory,
 	)
-	provider := vip3auth.ComposeWithFosite(oriProvider.(*fosite.Fosite), fc, store, commonStrategy, jwtStrategy)
+	tokenJwtStrategy := vip3auth.NewProxyJWTStrategy(jwtStrategy.ES256JWTStrategy)
+	provider := vip3auth.ComposeWithFosite(oriProvider.(*fosite.Fosite), fc, store, commonStrategy, tokenJwtStrategy)
 	return provider
 }
 

--- a/corp104/cmd/server/handler_oauth2_factory.go
+++ b/corp104/cmd/server/handler_oauth2_factory.go
@@ -145,7 +145,7 @@ func newOAuth2Provider(c *config.Config) fosite.OAuth2Provider {
 		compose.OAuth2TokenRevocationFactory,
 		compose.OAuth2TokenIntrospectionFactory,
 	)
-	provider := vip3auth.ComposeWithFosite(oriProvider.(*fosite.Fosite), fc, store, commonStrategy)
+	provider := vip3auth.ComposeWithFosite(oriProvider.(*fosite.Fosite), fc, store, commonStrategy, jwtStrategy)
 	return provider
 }
 

--- a/corp104/oauth2/handler.go
+++ b/corp104/oauth2/handler.go
@@ -23,11 +23,12 @@ package oauth2
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ory/hydra/corp104/resource"
 	"net/http"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/ory/hydra/corp104/resource"
 
 	jwt2 "github.com/dgrijalva/jwt-go"
 	"github.com/julienschmidt/httprouter"

--- a/corp104/oauth2/handler.go
+++ b/corp104/oauth2/handler.go
@@ -572,7 +572,6 @@ func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO 應該放在 AccessTokenStrategy 中處理
 	if h.AccessTokenStrategy == "jwt" {
 		accessTokenKeyID, err := h.AccessTokenJWTStrategy.GetPublicKeyID(r.Context())
 		if err != nil {
@@ -593,7 +592,6 @@ func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request) {
 		session.KID = accessTokenKeyID
 		session.DefaultSession.Claims.Issuer = strings.TrimRight(h.IssuerURL, "/") + "/"
 		session.DefaultSession.Claims.IssuedAt = time.Now().UTC()
-		session.GetJWTHeader().Add("cty", "resource-access-token+jwt")
 	}
 	// TODO: ScopeStrategy 暫時忽略
 


### PR DESCRIPTION
- 調整: 更新 github.com/104corp/vip3-go-auth 到 revision：31ea07a13dd06f2457e5d1e16f827f8096f335b2
- 調整: 簽發的 Access Token 如規格樣貌
`claim.cnf`: OK
`claim.sub`: OK
`claim.scope`: OK
`claim.urn:104:v3:entity:pid`: OK
`claim.urn:104:v3:entity:company_id`: OK
`header.typ`:OK