### PR TITLE
調整 SDK 以支援 Client Credentials Grant Flow

### DIFF
--- a/corp104/client/sdk_test.go
+++ b/corp104/client/sdk_test.go
@@ -133,7 +133,7 @@ func TestClientSDK(t *testing.T) {
 	server := httptest.NewServer(n)
 	c := hydra.NewOAuth2ApiWithBasePath(server.URL)
 	c.Configuration.PrivateJWK = cPrivJwk
-	c.Configuration.AuthSvcOfflinePublicJwk = authSrvPubJwk
+	c.Configuration.AuthSvcOfflinePublicJWK = authSrvPubJwk
 	handler.IssuerURL = server.URL
 
 	// start mock server

--- a/corp104/cmd/cli/handler_client.go
+++ b/corp104/cmd/cli/handler_client.go
@@ -89,7 +89,7 @@ func (h *ClientHandler) ImportClients(cmd *cobra.Command, args []string) {
 		var c hydra.OAuth2Client
 		err = json.NewDecoder(reader).Decode(&c)
 		pkg.Must(err, "Could not parse JSON: %s", err)
-		m.Configuration.AuthSvcOfflinePublicJwk = getAuthServicePublicJWK(cmd)
+		m.Configuration.AuthSvcOfflinePublicJWK = getAuthServicePublicJWK(cmd)
 		result, response, err := m.PutOAuth2Client(c)
 		checkResponse(response, err, http.StatusCreated)
 
@@ -128,7 +128,7 @@ func (h *ClientHandler) PutClient(cmd *cobra.Command, args []string) {
 	}
 
 	if getAuthServicePublicJWK(cmd) != nil {
-		m.Configuration.AuthSvcOfflinePublicJwk = getAuthServicePublicJWK(cmd)
+		m.Configuration.AuthSvcOfflinePublicJWK = getAuthServicePublicJWK(cmd)
 	}
 	m.Configuration.PrivateJWK = signingJwk
 	result, response, err := m.PutOAuth2Client(cc)

--- a/corp104/cmd/cli/handler_client.go
+++ b/corp104/cmd/cli/handler_client.go
@@ -81,6 +81,7 @@ func (h *ClientHandler) ImportClients(cmd *cobra.Command, args []string) {
 		fmt.Println("Invalid signing jwk:", err.Error())
 		return
 	}
+	m.Configuration.PrivateJWK = signingJwk
 
 	for _, path := range args {
 		reader, err := os.Open(path)
@@ -88,8 +89,8 @@ func (h *ClientHandler) ImportClients(cmd *cobra.Command, args []string) {
 		var c hydra.OAuth2Client
 		err = json.NewDecoder(reader).Decode(&c)
 		pkg.Must(err, "Could not parse JSON: %s", err)
-
-		result, response, err := m.PutOAuth2Client(c, signingJwk, getAuthServicePublicJWK(cmd))
+		m.Configuration.AuthSvcOfflinePublicJwk = getAuthServicePublicJWK(cmd)
+		result, response, err := m.PutOAuth2Client(c)
 		checkResponse(response, err, http.StatusCreated)
 
 		/*
@@ -122,11 +123,15 @@ func (h *ClientHandler) PutClient(cmd *cobra.Command, args []string) {
 			err := errors.New("AD user credentials required")
 			pkg.Must(err, "Error: Required flag(s) \"user\" or \"pwd\" have/has not been set")
 		}
-		m.Configuration.Username = user
-		m.Configuration.Password = pwd
+		m.Configuration.ADUsername = user
+		m.Configuration.ADPassword = pwd
 	}
 
-	result, response, err := m.PutOAuth2Client(cc, signingJwk, getAuthServicePublicJWK(cmd))
+	if getAuthServicePublicJWK(cmd) != nil {
+		m.Configuration.AuthSvcOfflinePublicJwk = getAuthServicePublicJWK(cmd)
+	}
+	m.Configuration.PrivateJWK = signingJwk
+	result, response, err := m.PutOAuth2Client(cc)
 	if err != nil {
 		pkg.Must(err, "Error: "+err.Error())
 	}

--- a/corp104/cmd/cli/handler_resource.go
+++ b/corp104/cmd/cli/handler_resource.go
@@ -57,10 +57,11 @@ func (h *ResourceHandler) PutResource(cmd *cobra.Command, args []string) {
 		err := errors.New("AD user credentials required")
 		pkg.Must(err, "Error: Required flag(s) \"user\" or \"pwd\" have/has not been set")
 	}
-	m.Configuration.Username = user
-	m.Configuration.Password = pwd
-
-	result, response, err := m.PutOAuth2Resource(cc, signingJwk, getAuthServicePublicJWK(cmd))
+	m.Configuration.ADUsername = user
+	m.Configuration.ADPassword = pwd
+	m.Configuration.AuthSvcOfflinePublicJwk = getAuthServicePublicJWK(cmd)
+	m.Configuration.PrivateJWK = signingJwk
+	result, response, err := m.PutOAuth2Resource(cc)
 	if err != nil {
 		pkg.Must(err, "Error: "+err.Error())
 	}

--- a/corp104/cmd/cli/handler_resource.go
+++ b/corp104/cmd/cli/handler_resource.go
@@ -59,7 +59,7 @@ func (h *ResourceHandler) PutResource(cmd *cobra.Command, args []string) {
 	}
 	m.Configuration.ADUsername = user
 	m.Configuration.ADPassword = pwd
-	m.Configuration.AuthSvcOfflinePublicJwk = getAuthServicePublicJWK(cmd)
+	m.Configuration.AuthSvcOfflinePublicJWK = getAuthServicePublicJWK(cmd)
 	m.Configuration.PrivateJWK = signingJwk
 	result, response, err := m.PutOAuth2Resource(cc)
 	if err != nil {

--- a/corp104/resource/sdk_test.go
+++ b/corp104/resource/sdk_test.go
@@ -85,7 +85,7 @@ func TestResourceSDK(t *testing.T) {
 	server := httptest.NewServer(n)
 	c := hydra.NewOAuth2ApiWithBasePath(server.URL)
 	c.Configuration.PrivateJWK = cPrivJwk
-	c.Configuration.AuthSvcOfflinePublicJwk = authSrvPubJwk
+	c.Configuration.AuthSvcOfflinePublicJWK = authSrvPubJwk
 	handler.IssuerURL = server.URL
 
 	// start mock server

--- a/corp104/resource/sdk_test.go
+++ b/corp104/resource/sdk_test.go
@@ -84,6 +84,8 @@ func TestResourceSDK(t *testing.T) {
 	n.UseHandler(router)
 	server := httptest.NewServer(n)
 	c := hydra.NewOAuth2ApiWithBasePath(server.URL)
+	c.Configuration.PrivateJWK = cPrivJwk
+	c.Configuration.AuthSvcOfflinePublicJwk = authSrvPubJwk
 	handler.IssuerURL = server.URL
 
 	// start mock server
@@ -108,20 +110,20 @@ func TestResourceSDK(t *testing.T) {
 			createResource := tc.resource
 
 			t.Run("case=create resource with invalid user credentials", func(t *testing.T) {
-				c.Configuration.Username = "foo.bar"
-				c.Configuration.Password = "wrong"
+				c.Configuration.ADUsername = "foo.bar"
+				c.Configuration.ADPassword = "wrong"
 
-				_, response, err := c.PutOAuth2Resource(createResource, cPrivJwk, authSrvPubJwk)
+				_, response, err := c.PutOAuth2Resource(createResource)
 				require.NoError(t, err)
 				require.EqualValues(t, http.StatusUnauthorized, response.StatusCode)
 			})
 
 			t.Run("case=create resource", func(t *testing.T) {
-				c.Configuration.Username = "foo.bar"
-				c.Configuration.Password = "secret"
+				c.Configuration.ADUsername = "foo.bar"
+				c.Configuration.ADPassword = "secret"
 
 				// returned resource is correct on Create (session only)
-				result, response, err := c.PutOAuth2Resource(createResource, cPrivJwk, authSrvPubJwk)
+				result, response, err := c.PutOAuth2Resource(createResource)
 				require.NoError(t, err)
 				require.EqualValues(t, http.StatusAccepted, response.StatusCode, "%s", response.Payload)
 				assert.NotEmpty(t, result)
@@ -149,7 +151,7 @@ func TestResourceSDK(t *testing.T) {
 						updateResource.Scopes = append(updateResource.Scopes, )
 						updateResource.Description = updateResource.Description+"-updated"
 
-						_, response, err := c.PutOAuth2Resource(updateResource, cPrivJwk, authSrvPubJwk)
+						_, response, err := c.PutOAuth2Resource(updateResource)
 						require.NoError(t, err)
 						require.EqualValues(t, http.StatusAccepted, response.StatusCode, "%s", response.Payload)
 

--- a/corp104/sdk/go/corp104/sdk_api.go
+++ b/corp104/sdk/go/corp104/sdk_api.go
@@ -48,12 +48,12 @@ type OAuth2API interface {
 	GetLoginRequest(challenge string) (*swagger.LoginRequest, *swagger.APIResponse, error)
 	GetConsentRequest(challenge string) (*swagger.ConsentRequest, *swagger.APIResponse, error)
 
-	PutOAuth2Client(body swagger.OAuth2Client, signingJwk *swagger.JsonWebKey, authSrvPubJwk *swagger.JsonWebKey) (*swagger.PutClientResponse, *swagger.APIResponse, error)
+	PutOAuth2Client(body swagger.OAuth2Client) (*swagger.PutClientResponse, *swagger.APIResponse, error)
 	DeleteOAuth2Client(id string) (*swagger.APIResponse, error)
 	GetOAuth2Client(id, secret string) (*swagger.OAuth2Client, *swagger.APIResponse, error)
-	GetWellKnown(*swagger.JsonWebKey) (*swagger.WellKnown, *swagger.APIResponse, error)
+	GetWellKnown() (*swagger.WellKnown, *swagger.APIResponse, error)
 	IntrospectOAuth2Token(token string, scope string) (*swagger.OAuth2TokenIntrospection, *swagger.APIResponse, error)
-	ListOAuth2Clients(authSrvPubJwk *swagger.JsonWebKey, limit int64, offset int64) ([]swagger.OAuth2Client, *swagger.APIResponse, error)
+	ListOAuth2Clients(limit int64, offset int64) ([]swagger.OAuth2Client, *swagger.APIResponse, error)
 	RevokeOAuth2Token(token string) (*swagger.APIResponse, error)
 	RevokeAllUserConsentSessions(user string) (*swagger.APIResponse, error)
 	RevokeAuthenticationSession(user string) (*swagger.APIResponse, error)
@@ -63,9 +63,9 @@ type OAuth2API interface {
 	ListUserConsentSessions(user string) ([]swagger.PreviousConsentSession, *swagger.APIResponse, error)
 	FlushInactiveOAuth2Tokens(body swagger.FlushInactiveOAuth2TokensRequest) (*swagger.APIResponse, error)
 
-	PutOAuth2Resource(body swagger.OAuth2Resource, signingJwk *swagger.JsonWebKey, authSrvPubJwk *swagger.JsonWebKey) (*swagger.PutResourceResponse, *swagger.APIResponse, error)
+	PutOAuth2Resource(body swagger.OAuth2Resource) (*swagger.PutResourceResponse, *swagger.APIResponse, error)
 	CommitOAuth2Resource(cookies map[string]string, commitCode string) (*swagger.CommitResourceResponse, *swagger.APIResponse, error)
 	DeleteOAuth2Resource(urn string) (*swagger.APIResponse, error)
 	GetOAuth2Resource(urn string) (*swagger.OAuth2Resource, *swagger.APIResponse, error)
-	ListOAuth2Resources(authSrvPubJwk *swagger.JsonWebKey, limit int64, offset int64) ([]swagger.OAuth2Resource, *swagger.APIResponse, error)
+	ListOAuth2Resources(limit int64, offset int64) ([]swagger.OAuth2Resource, *swagger.APIResponse, error)
 }

--- a/corp104/sdk/go/corp104/swagger/README.md
+++ b/corp104/sdk/go/corp104/swagger/README.md
@@ -40,6 +40,7 @@ Class | Method | HTTP request | Description
 *OAuth2Api* | [**GetConsentRequest**](docs/OAuth2Api.md#getconsentrequest) | **Get** /oauth2/auth/requests/consent/{challenge} | Get consent request information
 *OAuth2Api* | [**GetLoginRequest**](docs/OAuth2Api.md#getloginrequest) | **Get** /oauth2/auth/requests/login/{challenge} | Get an login request
 *OAuth2Api* | [**GetOAuth2Client**](docs/OAuth2Api.md#getoauth2client) | **Get** /clients/{id} | Get an OAuth 2.0 Client.
+*OAuth2Api* | [**GetOAuth2Token**](docs/OAuth2Api.md#getoauth2token) | **Post** /token | Get an OAuth 2.0 access token.
 *OAuth2Api* | [**GetWellKnown**](docs/OAuth2Api.md#getwellknown) | **Get** /.well-known/oauth-authorization-server | Server well known configuration
 *OAuth2Api* | [**IntrospectOAuth2Token**](docs/OAuth2Api.md#introspectoauth2token) | **Post** /oauth2/introspect | Introspect OAuth2 tokens
 *OAuth2Api* | [**ListOAuth2Clients**](docs/OAuth2Api.md#listoauth2clients) | **Get** /clients | List OAuth 2.0 Clients

--- a/corp104/sdk/go/corp104/swagger/configuration.go
+++ b/corp104/sdk/go/corp104/swagger/configuration.go
@@ -60,7 +60,7 @@ type Configuration struct {
 	CacheCleanupInterval 	*time.Duration
 
 	// Auth service's offline public JWK
-	AuthSvcOfflinePublicJwk *JsonWebKey `json:"authSvcOfflinePublicJWK,omitempty"`
+	AuthSvcOfflinePublicJWK *JsonWebKey `json:"authSvcOfflinePublicJWK,omitempty"`
 
 	// Client's JWKS
 	PrivateJWK *JsonWebKey `json:"privateJWK,omitempty"`

--- a/corp104/sdk/go/corp104/swagger/configuration.go
+++ b/corp104/sdk/go/corp104/swagger/configuration.go
@@ -55,7 +55,19 @@ type Configuration struct {
 	Transport     http.RoundTripper
 	Timeout       *time.Duration `json:"timeout,omitempty"`
 
-	Cache         *cache.Cache
+	cache         			*cache.Cache
+	CacheDefaultExpiration	*time.Duration
+	CacheCleanupInterval 	*time.Duration
+
+	// Auth service's offline public JWK
+	AuthSvcOfflinePublicJwk *JsonWebKey `json:"authSvcOfflinePublicJWK,omitempty"`
+
+	// Client's JWKS
+	PrivateJWK *JsonWebKey `json:"privateJWK,omitempty"`
+
+	// AD credentials
+	ADUsername string `json:"adUserName,omitempty"`
+	ADPassword string `json:"adPassword,omitempty"`
 }
 
 func NewConfiguration() *Configuration {
@@ -66,8 +78,9 @@ func NewConfiguration() *Configuration {
 		APIKeyPrefix:  make(map[string]string),
 		UserAgent:     "Swagger-Codegen/1.0.0/go",
 		APIClient:     &APIClient{},
-		Cache:         cache.New(5*time.Minute, 10*time.Minute),
 	}
+	// 預設開啟 cache
+	cfg.EnableCache(true)
 
 	cfg.APIClient.config = cfg
 	return cfg
@@ -87,4 +100,49 @@ func (c *Configuration) GetAPIKeyWithPrefix(APIKeyIdentifier string) string {
 	}
 
 	return c.APIKey[APIKeyIdentifier]
+}
+
+func (c *Configuration) EnableCache(enable bool) {
+	if enable {
+		if c.IsCacheEnabled() {
+			return
+		}
+
+		if c.CacheDefaultExpiration == nil {
+			defaultExpiration := 5 * time.Minute
+			c.CacheDefaultExpiration = &defaultExpiration
+		}
+		if c.CacheCleanupInterval == nil {
+			cleanupInterval := 10 * time.Minute
+			c.CacheCleanupInterval = &cleanupInterval
+		}
+		c.cache = cache.New(*c.CacheDefaultExpiration, *c.CacheCleanupInterval)
+	} else {
+		c.cache = nil
+	}
+}
+
+func (c *Configuration) IsCacheEnabled() bool {
+	if c.cache != nil {
+		return true
+	}
+	return false
+}
+
+// Add an item to the cache, replacing any existing item. If the duration is 0
+// (DefaultExpiration), the cache's default expiration time is used. If it is -1
+// (NoExpiration), the item never expires.
+func (c *Configuration) cacheSet(key string, value interface{}, expiration time.Duration) {
+	if c.IsCacheEnabled() {
+		c.cache.Set(key, value, expiration)
+	}
+}
+
+// Get an item from the cache. Returns the item or nil, and a bool indicating
+// whether the key was found.
+func (c *Configuration) cacheGet(key string) (interface{}, bool) {
+	if c.IsCacheEnabled() {
+		return c.cache.Get(key)
+	}
+	return nil, false
 }

--- a/corp104/sdk/go/corp104/swagger/docs/OAuth2Api.md
+++ b/corp104/sdk/go/corp104/swagger/docs/OAuth2Api.md
@@ -33,6 +33,7 @@ Method | HTTP request | Description
 [**GetOAuth2Resource**](OAuth2Api.md#GetOAuth2Resource) | **Get** /resources/{urn} | Get an OAuth 2.0 Resource
 [**ListOAuth2Resources**](OAuth2Api.md#ListOAuth2Resources) | **Get** /resources | List OAuth 2.0 Resources
 [**PutOAuth2Resource**](OAuth2Api.md#PutOAuth2Resource) | **Put** /resources | Create or update an OAuth 2.0 Resource
+[**GetOAuth2Token**](OAuth2Api.md#OauthToken) | **Post** /token | Get OAuth 2.0 token
 
 
 
@@ -240,7 +241,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **GetOAuth2Client**
-> OAuth2Client GetOAuth2Client($id)
+> OAuth2Client GetOAuth2Client($id, $secret)
 
 Get an OAuth 2.0 Client.
 
@@ -326,7 +327,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **ListOAuth2Clients**
-> []OAuth2Client ListOAuth2Clients($authSrvPubJwk, $limit, $offset)
+> []OAuth2Client ListOAuth2Clients$limit, $offset)
 
 List OAuth 2.0 Clients
 
@@ -337,7 +338,6 @@ This endpoint lists all clients in the database, and never returns client secret
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **authSrvPubJwk** | **JsonWebKey**| The public key of the auth service. |
  **limit** | **int64**| The maximum amount of policies returned. | [optional] 
  **offset** | **int64**| The offset from where to start looking. | [optional] 
 
@@ -412,7 +412,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **OauthToken**
-> OauthTokenResponse OauthToken()
+> OauthTokenResponse OauthToken($clientAssertion, $resource, $scope)
 
 The OAuth 2.0 token endpoint
 
@@ -420,7 +420,13 @@ This endpoint is not documented here because you should never use your own imple
 
 
 ### Parameters
-This endpoint does not need any parameter.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **$clientAssertion** | **string** | client assertion JWT |
+ **resource** | **string** | resource 參數必須是空白（' '即 ASCII 0x20）分隔 Resource 的 URI 或 URN |
+ **scope** | **string** | scope 可以是任何 resouce 的 scope |
+
 
 ### Return type
 
@@ -450,9 +456,7 @@ OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usuall
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **body** | [**OAuth2Client**](OAuth2Client.md)|  |
- **signingJwk** | [**JsonWebKey**](JsonWebKey.md)| JWK for signing software statement |
- **authSrvPubJwk** | [**JsonWebKey**](JsonWebKey.md)| Auth Service's public JWK | 
-
+ 
 ### Return type
 
 [**PutClientResponse**](PutClientResponse.md)
@@ -809,7 +813,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **ListOAuth2Resources**
-> []OAuth2Resource ListOAuth2Resources($authSrvPubJwk, $limit, $offset)
+> []OAuth2Resource ListOAuth2Resources($limit, $offset)
 
 List OAuth 2.0 Resources
 
@@ -820,7 +824,6 @@ This endpoint lists all resources in the database.
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **authSrvPubJwk** | **JsonWebKey**| The public key of the auth service. |
  **limit** | **int64**| The maximum amount of policies returned. | [optional] 
  **offset** | **int64**| The offset from where to start looking. | [optional] 
  
@@ -840,7 +843,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **PutOAuth2Resource**
-> PutResourceResponse PutOAuth2Resource($body, $signingJwk, $authSrvPubJwk)
+> PutResourceResponse PutOAuth2Resource($body)
 
 Create or update an OAuth 2.0 resource.
 
@@ -849,9 +852,7 @@ Create or update an OAuth 2.0 resource.
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **body** | [**OAuth2Resource**](OAuth2Resource.md)|  |
- **signingJwk** | [**JsonWebKey**](JsonWebKey.md)| JWK for signing resource statement |
- **authSrvPubJwk** | [**JsonWebKey**](JsonWebKey.md)| Auth Service's public JWK | 
-
+ 
 ### Return type
 
 [**PutResourceResponse**](PutResourceResponse.md)
@@ -867,3 +868,29 @@ AD user credentials required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
+# **GetOAuth2Token**
+> OauthTokenResponse GetOAuth2Token($resource, $scope)
+
+Get an OAuth 2.0 access token.
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **resource** | **string** | space-separated list of resource URNs |
+ **scope** | **string** | space-separated list of scope values |
+ 
+### Return type
+
+[**OauthTokenResponse**](oauthTokenResponse.md)
+
+### Authorization
+
+Client assertion required 
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/corp104/sdk/go/corp104/swagger/docs/OauthTokenResponse.md
+++ b/corp104/sdk/go/corp104/swagger/docs/OauthTokenResponse.md
@@ -5,9 +5,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **AccessToken** | **string** | The access token issued by the authorization server. | [optional] [default to null]
 **ExpiresIn** | **int64** | The lifetime in seconds of the access token.  For example, the value \&quot;3600\&quot; denotes that the access token will expire in one hour from the time the response was generated. | [optional] [default to null]
-**IdToken** | **int64** | To retrieve a refresh token request the id_token scope. | [optional] [default to null]
+**IdToken** | **string** | To retrieve a refresh token request the id_token scope. | [optional] [default to null]
 **RefreshToken** | **string** | The refresh token, which can be used to obtain new access tokens. To retrieve it add the scope \&quot;offline\&quot; to your access token request. | [optional] [default to null]
-**Scope** | **int64** | The scope of the access token | [optional] [default to null]
+**Scope** | **string** | The scope of the access token | [optional] [default to null]
 **TokenType** | **string** | The type of the token issued | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/corp104/sdk/go/corp104/swagger/o_auth2_api.go
+++ b/corp104/sdk/go/corp104/swagger/o_auth2_api.go
@@ -2247,25 +2247,7 @@ func (a OAuth2Api) GetOAuth2Token(resource, scope string) (*OauthTokenResponse, 
 // Get access token cache
 // tokenCacheKey format: token#<resource_hash>#<scope_hash>
 func (a OAuth2Api) getTokenCacheKey(resource, scope string) string {
-	tokenCacheKey := CacheOauthTokenPrefix
-
-	var resourceHash string
-	if resource != "" {
-		resourceHash = getHexEncodedHashString(resource)
-	} else {
-		resourceHash = getHexEncodedHashString("")
-	}
-	tokenCacheKey += resourceHash
-
-	var scopeHash string
-	if scope != "" {
-		scopeHash = getHexEncodedHashString(scope)
-	} else {
-		scopeHash = getHexEncodedHashString("")
-	}
-	tokenCacheKey += "#" + scopeHash
-
-	return tokenCacheKey
+	return CacheOauthTokenPrefix + getHexEncodedHashString(resource + "@" + scope)
 }
 
 // 檢查 token 是否有效 (未過期且 PoP private key 有效)，Token 有效時返回 PoP Private Key

--- a/corp104/sdk/go/corp104/swagger/o_auth2_api.go
+++ b/corp104/sdk/go/corp104/swagger/o_auth2_api.go
@@ -193,8 +193,8 @@ func (a OAuth2Api) AcceptLoginRequest(challenge string, body AcceptLoginRequest)
  * @return *PutClientResponse
  */
 func (a OAuth2Api) PutOAuth2Client(body OAuth2Client) (*PutClientResponse, *APIResponse, error) {
-	if a.Configuration.AuthSvcOfflinePublicJwk == nil {
-		return nil, nil, errors.New("'Configuration.AuthSvcOfflinePublicJwk' must be set")
+	if a.Configuration.AuthSvcOfflinePublicJWK == nil {
+		return nil, nil, errors.New("'Configuration.AuthSvcOfflinePublicJWK' must be set")
 	}
 
 	var localVarHttpMethod = http.MethodPut
@@ -587,10 +587,10 @@ func (a OAuth2Api) GetOAuth2Client(id, secret string) (*OAuth2Client, *APIRespon
  * @return *WellKnown
  */
 func (a OAuth2Api) GetWellKnown() (*WellKnown, *APIResponse, error) {
-	if a.Configuration.AuthSvcOfflinePublicJwk == nil {
-		return nil, nil, errors.New("'Configuration.AuthSvcOfflinePublicJwk' must be set")
+	if a.Configuration.AuthSvcOfflinePublicJWK == nil {
+		return nil, nil, errors.New("'Configuration.AuthSvcOfflinePublicJWK' must be set")
 	}
-	authSrvPubJwk := a.Configuration.AuthSvcOfflinePublicJwk
+	authSrvPubJwk := a.Configuration.AuthSvcOfflinePublicJWK
 
 	if authServerMetadata, found := a.Configuration.cacheGet(CacheOAuthServerMetadata); found {
 		return authServerMetadata.(*WellKnown), nil, nil
@@ -757,10 +757,10 @@ func (a OAuth2Api) IntrospectOAuth2Token(token string, scope string) (*OAuth2Tok
  * @return []OAuth2Client
  */
 func (a OAuth2Api) ListOAuth2Clients(limit int64, offset int64) ([]OAuth2Client, *APIResponse, error) {
-	if a.Configuration.AuthSvcOfflinePublicJwk == nil {
-		return nil, nil, errors.New("'Configuration.AuthSvcOfflinePublicJwk' must be set")
+	if a.Configuration.AuthSvcOfflinePublicJWK == nil {
+		return nil, nil, errors.New("'Configuration.AuthSvcOfflinePublicJWK' must be set")
 	}
-	authSvcOfflinePubKey := a.Configuration.AuthSvcOfflinePublicJwk
+	authSvcOfflinePubKey := a.Configuration.AuthSvcOfflinePublicJWK
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -1695,11 +1695,11 @@ func (a OAuth2Api) CommitOAuth2Client(cookies map[string]string, commitCode stri
 }
 
 func (a OAuth2Api) createSoftwareStatement(body OAuth2Client) (string, error) {
-	if a.Configuration.AuthSvcOfflinePublicJwk == nil {
-		return "", errors.New("'Configuration.AuthSvcOfflinePublicJwk' must be set")
+	if a.Configuration.AuthSvcOfflinePublicJWK == nil {
+		return "", errors.New("'Configuration.AuthSvcOfflinePublicJWK' must be set")
 	}
 
-	serverPubJwk, serverPubKey, err := convertToJwxJWK(a.Configuration.AuthSvcOfflinePublicJwk)
+	serverPubJwk, serverPubKey, err := convertToJwxJWK(a.Configuration.AuthSvcOfflinePublicJWK)
 	if err != nil {
 		return "", err
 	}
@@ -1762,8 +1762,8 @@ func (a OAuth2Api) createSoftwareStatement(body OAuth2Client) (string, error) {
  * @return *PutResourceResponse
  */
 func (a OAuth2Api) PutOAuth2Resource(body OAuth2Resource) (*PutResourceResponse, *APIResponse, error) {
-	if a.Configuration.AuthSvcOfflinePublicJwk == nil {
-		return nil, nil, errors.New("'Configuration.AuthSvcOfflinePublicJwk' must be set")
+	if a.Configuration.AuthSvcOfflinePublicJWK == nil {
+		return nil, nil, errors.New("'Configuration.AuthSvcOfflinePublicJWK' must be set")
 	}
 
 	var localVarHttpMethod = http.MethodPut
@@ -1838,10 +1838,10 @@ func (a OAuth2Api) PutOAuth2Resource(body OAuth2Resource) (*PutResourceResponse,
 }
 
 func (a OAuth2Api) createResourceStatement(body OAuth2Resource) (string, error) {
-	if a.Configuration.AuthSvcOfflinePublicJwk == nil {
-		return "", errors.New("'Configuration.AuthSvcOfflinePublicJwk' must be set")
+	if a.Configuration.AuthSvcOfflinePublicJWK == nil {
+		return "", errors.New("'Configuration.AuthSvcOfflinePublicJWK' must be set")
 	}
-	serverPubJwk, serverPubKey, err := convertToJwxJWK(a.Configuration.AuthSvcOfflinePublicJwk)
+	serverPubJwk, serverPubKey, err := convertToJwxJWK(a.Configuration.AuthSvcOfflinePublicJWK)
 	if err != nil {
 		return "", err
 	}
@@ -2111,10 +2111,10 @@ func (a OAuth2Api) GetOAuth2Resource(urn string) (*OAuth2Resource, *APIResponse,
  * @return []OAuth2Resource
  */
 func (a OAuth2Api) ListOAuth2Resources(limit int64, offset int64) ([]OAuth2Resource, *APIResponse, error) {
-	if a.Configuration.AuthSvcOfflinePublicJwk == nil {
-		return nil, nil, errors.New("'Configuration.AuthSvcOfflinePublicJwk' must be set")
+	if a.Configuration.AuthSvcOfflinePublicJWK == nil {
+		return nil, nil, errors.New("'Configuration.AuthSvcOfflinePublicJWK' must be set")
 	}
-	authSvcOfflinePubKey := a.Configuration.AuthSvcOfflinePublicJwk
+	authSvcOfflinePubKey := a.Configuration.AuthSvcOfflinePublicJWK
 
 	var localVarHttpMethod = http.MethodGet
 	// create path and map variables

--- a/corp104/sdk/go/corp104/swagger/o_auth2_api_test.go
+++ b/corp104/sdk/go/corp104/swagger/o_auth2_api_test.go
@@ -1,13 +1,15 @@
 package swagger_test
 
 import (
-	"fmt"
 	. "github.com/ory/hydra/corp104/sdk/go/corp104/swagger"
+	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
+	"net/http"
 	"testing"
 	"time"
 )
 
+// [Prerequisite] register resources & clients before testing
 func _TestOAuth2API(t *testing.T) {
 	var serverURL = "http://localhost:4444"
 
@@ -15,39 +17,131 @@ func _TestOAuth2API(t *testing.T) {
 	timeout := 5 * time.Second
 	oauth2Api.Configuration.Timeout = &timeout
 
-	authSrvPubKey := &JsonWebKey{
+	oauth2Api.Configuration.PrivateJWK = &JsonWebKey{
+		Crv: "P-256",
+		Alg: "ES256",
+		Kty: "EC",
+		Use: "sig",
+		Kid: "private:89b940e8-a16f-48ce-a238-b52d7e252634",
+		X: "6yi0V0cyxGVc5fEiu2U2PuZr4TxavTguccdcco1XyuA",
+		Y: "kX_biw0hYHyt1qaVP4EbP7WScIu9QyPK0Aj3fXpBRCg",
+		D: "G4ExPHksANQZgLJzElHUGL43The7h0AKJE69qrgcZRo",
+	}
+
+	oauth2Api.Configuration.AuthSvcOfflinePublicJwk = &JsonWebKey{
+		Crv: "P-256",
+		Alg: "ES256",
 		Use: "sig",
 		Kty: "EC",
 		Kid: "public:7c337717-688f-453a-8c5e-d4601b4f79b6",
-		Crv: "P-256",
-		Alg: "ES256",
 		X:   "SuUAlWvVgSSnyUlu6D5lKryGW71Zlp6iHils0iekJn4",
 		Y:   "-RlN-Kk9VtncQ4Oev5rQGNTvruZ63mz_2XSACU2Jpt8",
 	}
 
 	t.Run("case=get oauth authorization server metadata", func(t *testing.T) {
-		wellKnown, _, err := oauth2Api.GetWellKnown(authSrvPubKey)
+		wellKnown, _, err := oauth2Api.GetWellKnown()
 		assert.NoError(t, err)
 		assert.NotEmpty(t, wellKnown.Issuer)
-		fmt.Println("WellKnown: ", wellKnown)
 	})
 
 	t.Run("case=get oauth authorization server jwks.json", func(t *testing.T) {
 		jwks, _, err := oauth2Api.WellKnown()
 		assert.NoError(t, err)
 		assert.NotNil(t, jwks)
-		fmt.Println("jwks: ", jwks)
 	})
 
 	t.Run("case=get oauth 2.0 client", func(t *testing.T) {
-		clients, _, err := oauth2Api.ListOAuth2Clients(authSrvPubKey, 100, 0)
+		// [WARNING] this is for backend admin router only
+		clients, _, err := oauth2Api.ListOAuth2Clients(100, 0)
 		assert.NoError(t, err)
-		fmt.Println("clients: ", clients)
+		assert.NotEmpty(t, clients)
 	})
 
 	t.Run("case=get oauth 2.0 resources", func(t *testing.T) {
-		resources, _, err := oauth2Api.ListOAuth2Resources(authSrvPubKey, 100, 0)
+		resources, _, err := oauth2Api.ListOAuth2Resources(100, 0)
 		assert.NoError(t, err)
-		fmt.Println("resources: ", resources)
+		assert.NotEmpty(t, resources)
+	})
+
+	t.Run("case=get oauth 2.0 client assertion", func(t *testing.T) {
+		// set client ID & PrivateJWK
+		oauth2Api.Configuration.Username = "client:" + uuid.New()
+		popJWKS, err := oauth2Api.GetPoPKeyPair(uuid.New())
+		assert.NoError(t, err)
+		clientAssertion, err := oauth2Api.CreateOAuth2ClientAssertion(popJWKS)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, clientAssertion)
+	})
+
+	t.Run("case=get oauth 2.0 access token", func(t *testing.T) {
+		// Note: register client before running this test case
+		// set client ID & PrivateJWK
+		oauth2Api.Configuration.Username = "fa3030d2-9e16-4b7d-b27f-381e840175cb"
+		oauth2Api.Configuration.PrivateJWK = &JsonWebKey{
+			Crv: "P-256",
+			Alg: "ES256",
+			Kty: "EC",
+			Kid: "private:89b940e8-a16f-48ce-a238-b52d7e252634",
+			X: "6yi0V0cyxGVc5fEiu2U2PuZr4TxavTguccdcco1XyuA",
+			Y: "kX_biw0hYHyt1qaVP4EbP7WScIu9QyPK0Aj3fXpBRCg",
+			D: "G4ExPHksANQZgLJzElHUGL43The7h0AKJE69qrgcZRo",
+		}
+
+		token, popPrivKey, err := oauth2Api.GetOAuth2Token("", "")
+		assert.NoError(t, err)
+		assert.NotEmpty(t, token)
+		assert.NotEmpty(t, popPrivKey)
+	})
+
+	// test loadECDSAPublicKey
+	t.Run("case=load ecdsa private key from JsonWebKey", func(t *testing.T) {
+		jsonWebKey := &JsonWebKey{
+			Crv: "P-256",
+			Alg: "ES256",
+			Kty: "EC",
+			Use: "sig",
+			Kid: "public:89b940e8-a16f-48ce-a238-b52d7e252634",
+			X: "6yi0V0cyxGVc5fEiu2U2PuZr4TxavTguccdcco1XyuA",
+			Y: "kX_biw0hYHyt1qaVP4EbP7WScIu9QyPK0Aj3fXpBRCg",
+		}
+		ecPubKey, err := LoadECPublicKeyFromJsonWebKey(jsonWebKey)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, ecPubKey)
+	})
+
+	// test loadECDSAPrivateKey
+	t.Run("case=load ecdsa private key from JsonWebKey", func(t *testing.T) {
+		jsonWebKey := &JsonWebKey{
+			Crv: "P-256",
+			Alg: "ES256",
+			Kty: "EC",
+			Kid: "private:89b940e8-a16f-48ce-a238-b52d7e252634",
+			X: "6yi0V0cyxGVc5fEiu2U2PuZr4TxavTguccdcco1XyuA",
+			Y: "kX_biw0hYHyt1qaVP4EbP7WScIu9QyPK0Aj3fXpBRCg",
+			D: "G4ExPHksANQZgLJzElHUGL43The7h0AKJE69qrgcZRo",
+		}
+		ecPrivKey, err := LoadECPrivateKeyFromJsonWebKey(jsonWebKey)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, ecPrivKey)
+	})
+
+	// SendHttpGet
+	t.Run("case=send get request", func(t *testing.T) {
+		// Note: register resource first
+		oauth2Api.Configuration.Username = "fa3030d2-9e16-4b7d-b27f-381e840175cb"
+		apiResp, err := oauth2Api.SendHttpGet("http://localhost:4444/resources/urn:104:v3:resource:rest:jobs", nil)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, apiResp.StatusCode)
+		assert.NotEmpty(t, apiResp.Payload)
+	})
+
+	t.Run("case=test cache", func(t *testing.T) {
+		keyId := uuid.New()
+		jwks, err := oauth2Api.GetPoPKeyPair(keyId)
+		assert.NoError(t, err)
+		assert.NotNil(t, jwks)
+		cachedJwks, err := oauth2Api.GetPoPKeyPair(keyId)
+		assert.NoError(t, err)
+		assert.EqualValues(t, jwks, cachedJwks)
 	})
 }

--- a/corp104/sdk/go/corp104/swagger/o_auth2_api_test.go
+++ b/corp104/sdk/go/corp104/swagger/o_auth2_api_test.go
@@ -28,7 +28,7 @@ func _TestOAuth2API(t *testing.T) {
 		D: "G4ExPHksANQZgLJzElHUGL43The7h0AKJE69qrgcZRo",
 	}
 
-	oauth2Api.Configuration.AuthSvcOfflinePublicJwk = &JsonWebKey{
+	oauth2Api.Configuration.AuthSvcOfflinePublicJWK = &JsonWebKey{
 		Crv: "P-256",
 		Alg: "ES256",
 		Use: "sig",

--- a/corp104/sdk/go/corp104/swagger/oauth_token_response.go
+++ b/corp104/sdk/go/corp104/swagger/oauth_token_response.go
@@ -20,13 +20,13 @@ type OauthTokenResponse struct {
 	ExpiresIn int64 `json:"expires_in,omitempty"`
 
 	// To retrieve a refresh token request the id_token scope.
-	IdToken int64 `json:"id_token,omitempty"`
+	IdToken string `json:"id_token,omitempty"`
 
 	// The refresh token, which can be used to obtain new access tokens. To retrieve it add the scope \"offline\" to your access token request.
 	RefreshToken string `json:"refresh_token,omitempty"`
 
 	// The scope of the access token
-	Scope int64 `json:"scope,omitempty"`
+	Scope string `json:"scope,omitempty"`
 
 	// The type of the token issued
 	TokenType string `json:"token_type,omitempty"`


### PR DESCRIPTION
## 調整項目
1.  調整 Configuration struct (ie. SDK 的參數設定)
    - 新增 `PrivateJWK` 以設定 Client 的 private key
    - 新增 `AuthSvcOfflinePublicJWK` 以設定 Auth service 的 offline public key
    - 新增 `ADUsername` 與 `ADPassword ` 以設定 AD credentials
    - 調整 cache 設定
2. 調整 OauthTokenResponse struct 的 `IdToken` 及 `Scope` 的型別為 string
3. 調整 helper 輔助 functions
4. 調整 OAuth2Api
    - 新增 GetOauth2Token() 處理 PoP、Client Assertion 並返回 Token
    - 新增 SendHttpRequest() 以向 RS 發起 request 並自動處理 `Authorization`、`104-Track-Id`、`104-PoP-Timestamp`、`104-PoP-Signature`
    - 因應項目 1 調整，移除傳入的 PrivateJWK 及  AuthSvcOfflinePublicJWK
    - 因應項目 3 調整，調整 function call
5. 因應 Oauth2Api 介面調整，修改 swagger docs 

   